### PR TITLE
Remove postinit

### DIFF
--- a/astroid/as_string.py
+++ b/astroid/as_string.py
@@ -412,10 +412,13 @@ class AsStringVisitor(object):
         """yield an ast.Yield node as string"""
         yi_val = node.value and (" " + node.value.accept(self)) or ""
         expr = 'yield' + yi_val
-        if node.parent.is_statement:
-            return expr
-        else:
-            return "(%s)" % (expr,)
+        # TODO: this code can be restored when the as_string() visitor
+        # is made to work with the zipper.
+
+        # if node.parent.is_statement:
+        #     return expr
+        # else:
+        return "(%s)" % (expr,)
 
     def visit_starred(self, node):
         """return Starred node as string"""
@@ -453,10 +456,13 @@ class AsStringVisitor3(AsStringVisitor):
         """ Return an astroid.YieldFrom node as string. """
         yi_val = node.value and (" " + node.value.accept(self)) or ""
         expr = 'yield from' + yi_val
-        if node.parent.is_statement:
-            return expr
-        else:
-            return "(%s)" % (expr,)
+        # TODO: this code can be restored when the as_string() visitor
+        # is made to work with the zipper.
+
+        # if node.parent.is_statement:
+        #     return expr
+        # else:
+        return "(%s)" % (expr,)
 
     def visit_asyncfunctiondef(self, node):
         function = super(AsStringVisitor3, self).visit_functiondef(node)

--- a/astroid/base.py
+++ b/astroid/base.py
@@ -52,10 +52,9 @@ class BaseNode(object):
     # instance specific inference function infer(node, context)
     _explicit_inference = None
 
-    def __init__(self, lineno=None, col_offset=None, parent=None):
+    def __init__(self, lineno=None, col_offset=None):
         self.lineno = lineno
         self.col_offset = col_offset
-        self.parent = parent
  
     def __iter__(self):
         for field in self._astroid_fields:

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -970,26 +970,22 @@ class SetComp(BaseComprehension):
 
 
 class _ListComp(base.BaseNode):
-    _astroid_fields = ('generators', 'elt')
-    elt = base.Empty
-    generators = base.Empty
-
-    def __init__(self, generators, elt, lineno=None, col_offset=None):
-        self.generators = generators
-        self.elt = elt
-        # TODO: figure out a better solution here to inheritance for ListComp.
-
-        # super(_ListComp, self).__init__(lineno, col_offset)
-        self.lineno = lineno
-        self.col_offset = col_offset
-
+    pass
 
 if six.PY3:
     class ListComp(_ListComp, BaseComprehension):
         pass
 else:
     class ListComp(_ListComp):
-        pass
+        _astroid_fields = ('generators', 'elt')
+        elt = base.Empty
+        generators = base.Empty
+
+        # TODO: this still duplicates code in base comprehension.
+        def __init__(self, generators, elt, lineno=None, col_offset=None):
+            self.generators = generators
+            self.elt = elt
+            super(_ListComp, self).__init__(lineno, col_offset)
 
 
 class LambdaFunctionMixin(base.BaseNode):

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -353,7 +353,7 @@ class Const(base.BaseNode):
         self.value = value
         super(Const, self).__init__(lineno, col_offset, parent)
 
-    
+
 class NameConstant(Const):
     """Represents a builtin singleton, at the moment True, False, None and NotImplemented."""
 

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -36,12 +36,9 @@ class BaseContainer(base.BaseNode):
 
     _astroid_fields = ('elts',)
 
-    def __init__(self, lineno=None, col_offset=None, parent=None):
-        self.elts = []
-        super(BaseContainer, self).__init__(lineno, col_offset, parent)
-
-    def postinit(self, elts):
+    def __init__(self, elts, lineno=None, col_offset=None):
         self.elts = elts
+        super(BaseContainer, self).__init__(lineno, col_offset)
 
 
 class Statement(base.BaseNode):
@@ -52,9 +49,9 @@ class Statement(base.BaseNode):
 class BaseAssignName(base.BaseNode):
     _other_fields = ('name',)
 
-    def __init__(self, name=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, name, lineno=None, col_offset=None):
         self.name = name
-        super(BaseAssignName, self).__init__(lineno, col_offset, parent)
+        super(BaseAssignName, self).__init__(lineno, col_offset)
 
 
 class AssignName(BaseAssignName):
@@ -66,55 +63,43 @@ class Parameter(BaseAssignName):
     _astroid_fields = ('default', 'annotation')
     _other_fields = ('name', )
 
-    def __init__(self, name=None, lineno=None, col_offset=None, parent=None):
-        super(Parameter, self).__init__(name=name, lineno=lineno, col_offset=col_offset, parent=parent)
-
-    def postinit(self, default, annotation):
+    def __init__(self, name, default, annotation, lineno=None, col_offset=None):
+        self.name = name
         self.default = default
         self.annotation = annotation
+        super(Parameter, self).__init__(name=name, lineno=lineno, col_offset=col_offset)
 
 
 class DelName(base.BaseNode):
 
     _other_fields = ('name',)
 
-    def __init__(self, name=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, name, lineno=None, col_offset=None):
         self.name = name
-        super(DelName, self).__init__(lineno, col_offset, parent)
+        super(DelName, self).__init__(lineno, col_offset)
 
 
 class Name(base.BaseNode):
 
     _other_fields = ('name',)
 
-    def __init__(self, name=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, name, lineno=None, col_offset=None):
         self.name = name
-        super(Name, self).__init__(lineno, col_offset, parent)
-    
+        super(Name, self).__init__(lineno, col_offset)
+
 
 class Arguments(base.BaseNode):
 
     _astroid_fields = ('args', 'vararg', 'kwarg', 'keyword_only', 'positional_only')
 
-    def __init__(self, lineno=None, col_offset=None, parent=None):
-        # We don't want lineno and col_offset from the parent's __init__.
-        super(Arguments, self).__init__(parent=parent)
-
-    def postinit(self, args, vararg, kwarg, keyword_only, positional_only):
+    def __init__(self, args, vararg, kwarg, keyword_only, positional_only):
         self.args = args
         self.vararg = vararg
         self.kwarg = kwarg
         self.keyword_only = keyword_only
         self.positional_only = positional_only
         self.positional_and_keyword = self.args + self.positional_only
-
-    @property
-    def fromlineno(self):
-        # Let the Function's lineno be the lineno for this.
-        if self.parent.fromlineno:
-            return self.parent.fromlineno
-
-        return super(Arguments, self).fromlineno
+        super(Arguments, self).__init__(None, None)
 
     @staticmethod
     def _format_args(args):
@@ -200,12 +185,10 @@ class AssignAttr(base.BaseNode):
     _other_fields = ('attrname',)
     expr = base.Empty
 
-    def __init__(self, attrname=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, attrname, expr, lineno=None, col_offset=None):
         self.attrname = attrname
-        super(AssignAttr, self).__init__(lineno, col_offset, parent)
-
-    def postinit(self, expr=base.Empty):
         self.expr = expr
+        super(AssignAttr, self).__init__(lineno, col_offset)
 
 
 class Assert(Statement):
@@ -214,9 +197,10 @@ class Assert(Statement):
     test = base.Empty
     fail = base.Empty
 
-    def postinit(self, test=base.Empty, fail=base.Empty):
-        self.fail = fail
+    def __init__(self, test, fail, lineno=None, col_offset=None):
         self.test = test
+        self.fail = fail
+        super(Assert, self).__init__(lineno, col_offset)
 
 
 class Assign(Statement):
@@ -225,9 +209,10 @@ class Assign(Statement):
     targets = base.Empty
     value = base.Empty
 
-    def postinit(self, targets=base.Empty, value=base.Empty):
+    def __init__(self, targets, value, lineno=None, col_offset=None):
         self.targets = targets
         self.value = value
+        super(Assign, self).__init__(lineno, col_offset)
 
 
 class AugAssign(Statement):
@@ -237,13 +222,11 @@ class AugAssign(Statement):
     target = base.Empty
     value = base.Empty
 
-    def __init__(self, op=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, op, target, value, lineno=None, col_offset=None):
         self.op = op
-        super(AugAssign, self).__init__(lineno, col_offset, parent)
-
-    def postinit(self, target=base.Empty, value=base.Empty):
         self.target = target
         self.value = value
+        super(AugAssign, self).__init__(lineno, col_offset)
 
 
 class Repr(base.BaseNode):
@@ -251,8 +234,9 @@ class Repr(base.BaseNode):
     _astroid_fields = ('value',)
     value = base.Empty
 
-    def postinit(self, value=base.Empty):
+    def __init__(self, value, lineno=None, col_offset=None):
         self.value = value
+        super(Repr, self).__init__(lineno, col_offset)
 
 
 class BinOp(base.BaseNode):
@@ -262,13 +246,11 @@ class BinOp(base.BaseNode):
     left = base.Empty
     right = base.Empty
 
-    def __init__(self, op=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, op, left, right, lineno=None, col_offset=None):
         self.op = op
-        super(BinOp, self).__init__(lineno, col_offset, parent)
-
-    def postinit(self, left=base.Empty, right=base.Empty):
         self.left = left
         self.right = right
+        super(BinOp, self).__init__(lineno, col_offset)
 
 
 class BoolOp(base.BaseNode):
@@ -277,12 +259,10 @@ class BoolOp(base.BaseNode):
     _other_fields = ('op',)
     values = base.Empty
 
-    def __init__(self, op=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, op, values, lineno=None, col_offset=None):
         self.op = op
-        super(BoolOp, self).__init__(lineno, col_offset, parent)
-
-    def postinit(self, values=base.Empty):
         self.values = values
+        super(BoolOp, self).__init__(lineno, col_offset)
 
 
 class Break(Statement):
@@ -296,10 +276,11 @@ class Call(base.BaseNode):
     args = base.Empty
     keywords = base.Empty
 
-    def postinit(self, func=base.Empty, args=base.Empty, keywords=base.Empty):
+    def __init__(self, func, args, keywords, lineno=None, col_offset=None):
         self.func = func
         self.args = args
         self.keywords = keywords
+        super(Call, self).__init__(lineno, col_offset)
 
     @property
     def starargs(self):
@@ -319,14 +300,11 @@ class Compare(base.BaseNode):
     left = base.Empty
     comparators = base.Empty
 
-    def __init__(self, ops, lineno=None, col_offset=None, parent=None):
-        self.comparators = []
+    def __init__(self, ops, left, comparators, lineno=None, col_offset=None):
         self.ops = ops
-        super(Compare, self).__init__(lineno, col_offset, parent)
-
-    def postinit(self, left=base.Empty, comparators=base.Empty):
         self.left = left
         self.comparators = comparators
+        super(Compare, self).__init__(lineno, col_offset)
 
 
 class Comprehension(base.BaseNode):
@@ -336,22 +314,18 @@ class Comprehension(base.BaseNode):
     iter = base.Empty
     ifs = base.Empty
 
-    def __init__(self, parent=None):
-        self.parent = parent
-
-    def postinit(self, target=base.Empty, iter=base.Empty, ifs=base.Empty):
+    def __init__(self, target, iter, ifs):
         self.target = target
         self.iter = iter
-        self.ifs = ifs
 
 
 class Const(base.BaseNode):
     """Represent a constant node like num, str, bytes."""
     _other_fields = ('value',)
 
-    def __init__(self, value, lineno=None, col_offset=None, parent=None):
+    def __init__(self, value, lineno=None, col_offset=None):
         self.value = value
-        super(Const, self).__init__(lineno, col_offset, parent)
+        super(Const, self).__init__(lineno, col_offset)
 
 
 class NameConstant(Const):
@@ -367,8 +341,9 @@ class Decorators(base.BaseNode):
     _astroid_fields = ('nodes',)
     nodes = base.Empty
 
-    def postinit(self, nodes):
+    def __init__(self, nodes, lineno=None, col_offset=None):
         self.nodes = nodes
+        super(Decorators, self).__init__(lineno, col_offset)
 
 
 class DelAttr(base.BaseNode):
@@ -377,12 +352,10 @@ class DelAttr(base.BaseNode):
     _other_fields = ('attrname',)
     expr = base.Empty
 
-    def __init__(self, attrname=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, attrname, expr, lineno=None, col_offset=None):
         self.attrname = attrname
-        super(DelAttr, self).__init__(lineno, col_offset, parent)
-
-    def postinit(self, expr=base.Empty):
         self.expr = expr
+        super(DelAttr, self).__init__(lineno, col_offset)
 
 
 class Delete(Statement):
@@ -390,22 +363,19 @@ class Delete(Statement):
     _astroid_fields = ('targets',)
     targets = base.Empty
 
-    def postinit(self, targets=base.Empty):
+    def __init__(self, targets, lineno=None, col_offset=None):
         self.targets = targets
+        super(Delete, self).__init__(lineno, col_offset)
 
 
 class Dict(base.BaseNode):
 
     _astroid_fields = ('keys', 'values')
 
-    def __init__(self, lineno=None, col_offset=None, parent=None):
-        self.keys = []
-        self.values = []
-        super(Dict, self).__init__(lineno, col_offset, parent)
-
-    def postinit(self, keys, values):
+    def __init__(self, keys, values, lineno=None, col_offset=None):
         self.keys = keys
         self.values = values
+        super(Dict, self).__init__(lineno, col_offset)
 
     @property
     def items(self):
@@ -417,8 +387,9 @@ class Expr(Statement):
     _astroid_fields = ('value',)
     value = base.Empty
 
-    def postinit(self, value=base.Empty):
+    def __init__(self, value, lineno=None, col_offset=None):
         self.value = value
+        super(Expr, self).__init__(lineno, col_offset)
 
 
 class Ellipsis(base.BaseNode): # pylint: disable=redefined-builtin
@@ -432,10 +403,11 @@ class ExceptHandler(Statement):
     name = base.Empty
     body = base.Empty
 
-    def postinit(self, type=base.Empty, name=base.Empty, body=base.Empty):
+    def __init__(self, type, name, body, lineno=None, col_offset=None):
         self.type = type
         self.name = name
         self.body = body
+        super(ExceptHandler, self).__init__(lineno, col_offset)
 
     @property
     def blockstart_tolineno(self):
@@ -454,10 +426,11 @@ class Exec(Statement):
     globals = base.Empty
     locals = base.Empty
 
-    def postinit(self, expr=base.Empty, globals=base.Empty, locals=base.Empty):
+    def __init__(self, expr, globals, locals, lineno=None, col_offset=None):
         self.expr = expr
         self.globals = globals
         self.locals = locals
+        super(Exec, self).__init__(lineno, col_offset)
 
 
 class ExtSlice(base.BaseNode):
@@ -465,8 +438,9 @@ class ExtSlice(base.BaseNode):
     _astroid_fields = ('dims',)
     dims = base.Empty
 
-    def postinit(self, dims=base.Empty):
+    def __init__(self, dims, lineno=None, col_offset=None):
         self.dims = dims
+        super(ExtSlice, self).__init__(lineno, col_offset)
 
 
 class For(base.BlockRangeMixIn, Statement):
@@ -477,11 +451,12 @@ class For(base.BlockRangeMixIn, Statement):
     body = base.Empty
     orelse = base.Empty
 
-    def postinit(self, target=base.Empty, iter=base.Empty, body=base.Empty, orelse=base.Empty):
+    def __init__(self, target, iter, body, orelse, lineno=None, col_offset=None):
         self.target = target
         self.iter = iter
         self.body = body
         self.orelse = orelse
+        super(For, self).__init__(lineno, col_offset)
 
     optional_assign = True
 
@@ -500,19 +475,20 @@ class Await(base.BaseNode):
     _astroid_fields = ('value', )
     value = base.Empty
 
-    def postinit(self, value=base.Empty):
+    def __init__(self, value, lineno=None, col_offset=None):
         self.value = value
+        super(Await, self).__init__(lineno, col_offset)
 
 
 class ImportFrom(Statement):
 
     _other_fields = ('modname', 'names', 'level')
 
-    def __init__(self, fromname, names, level=0, lineno=None, col_offset=None, parent=None):
-        self.modname = fromname
+    def __init__(self, modname, names, level, lineno=None, col_offset=None):
+        self.modname = modname
         self.names = names
         self.level = level
-        super(ImportFrom, self).__init__(lineno, col_offset, parent)
+        super(ImportFrom, self).__init__(lineno, col_offset)
 
 
 class Attribute(base.BaseNode):
@@ -521,21 +497,19 @@ class Attribute(base.BaseNode):
     _other_fields = ('attrname',)
     expr = base.Empty
 
-    def __init__(self, attrname=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, attrname, expr, lineno=None, col_offset=None):
         self.attrname = attrname
-        super(Attribute, self).__init__(lineno, col_offset, parent)
-
-    def postinit(self, expr=base.Empty):
         self.expr = expr
+        super(Attribute, self).__init__(lineno, col_offset)
 
 
 class Global(Statement):
 
     _other_fields = ('names',)
 
-    def __init__(self, names, lineno=None, col_offset=None, parent=None):
+    def __init__(self, names, lineno=None, col_offset=None):
         self.names = names
-        super(Global, self).__init__(lineno, col_offset, parent)
+        super(Global, self).__init__(lineno, col_offset)
 
 
 class If(base.BlockRangeMixIn, Statement):
@@ -545,10 +519,11 @@ class If(base.BlockRangeMixIn, Statement):
     body = base.Empty
     orelse = base.Empty
 
-    def postinit(self, test=base.Empty, body=base.Empty, orelse=base.Empty):
+    def __init__(self, test, body, orelse, lineno=None, col_offset=None):
         self.test = test
         self.body = body
         self.orelse = orelse
+        super(If, self).__init__(lineno, col_offset)
 
     @property
     def blockstart_tolineno(self):
@@ -571,19 +546,20 @@ class IfExp(base.BaseNode):
     body = base.Empty
     orelse = base.Empty
 
-    def postinit(self, test=base.Empty, body=base.Empty, orelse=base.Empty):
+    def __init__(self, test, body, orelse, lineno=None, col_offset=None):
         self.test = test
         self.body = body
         self.orelse = orelse
+        super(IfExp, self).__init__(lineno, col_offset)
 
 
 class Import(Statement):
 
     _other_fields = ('names',)
 
-    def __init__(self, names=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, names, lineno=None, col_offset=None):
         self.names = names
-        super(Import, self).__init__(lineno, col_offset, parent)
+        super(Import, self).__init__(lineno, col_offset)
 
 
 class Index(base.BaseNode):
@@ -591,8 +567,9 @@ class Index(base.BaseNode):
     _astroid_fields = ('value',)
     value = base.Empty
 
-    def postinit(self, value=base.Empty):
+    def __init__(self, value, lineno=None, col_offset=None):
         self.value = value
+        super(Index, self).__init__(lineno, col_offset)
 
 
 class Keyword(base.BaseNode):
@@ -601,30 +578,28 @@ class Keyword(base.BaseNode):
     _other_fields = ('arg',)
     value = base.Empty
 
-    def __init__(self, arg=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, arg, value, lineno=None, col_offset=None):
         self.arg = arg
-        super(Keyword, self).__init__(lineno, col_offset, parent)
-
-    def postinit(self, value=base.Empty):
         self.value = value
+        super(Keyword, self).__init__(lineno, col_offset)
 
 
 class List(BaseContainer):
 
     _other_fields = ('ctx',)
 
-    def __init__(self, ctx=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, ctx, elts, lineno=None, col_offset=None):
         self.ctx = ctx
-        super(List, self).__init__(lineno, col_offset, parent)
+        super(List, self).__init__(elts, lineno, col_offset)
 
 
 class Nonlocal(Statement):
 
     _other_fields = ('names',)
 
-    def __init__(self, names, lineno=None, col_offset=None, parent=None):
+    def __init__(self, names, lineno=None, col_offset=None):
         self.names = names
-        super(Nonlocal, self).__init__(lineno, col_offset, parent)
+        super(Nonlocal, self).__init__(lineno, col_offset)
 
 
 class Pass(Statement):
@@ -633,27 +608,27 @@ class Pass(Statement):
 
 class Print(Statement):
 
-    _astroid_fields = ('dest', 'values',)
+    _astroid_fields = ('dest', 'values')
+    _other_fields = ('nl',)
     dest = base.Empty
     values = base.Empty
 
-    def __init__(self, nl=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, nl, dest, values, lineno=None, col_offset=None):
         self.nl = nl
-        super(Print, self).__init__(lineno, col_offset, parent)
-
-    def postinit(self, dest=base.Empty, values=base.Empty):
         self.dest = dest
         self.values = values
+        super(Print, self).__init__(lineno, col_offset)
 
 
 class Raise(Statement):
 
     _astroid_fields = ('exc', 'cause', 'traceback')
 
-    def postinit(self, exc=base.Empty, cause=base.Empty, traceback=base.Empty):
+    def __init__(self, exc, cause, traceback, lineno=None, col_offset=None):
         self.exc = exc
         self.cause = cause
         self.traceback = traceback
+        super(Raise, self).__init__(lineno, col_offset)
 
 
 class Return(Statement):
@@ -661,8 +636,9 @@ class Return(Statement):
     _astroid_fields = ('value',)
     value = base.Empty
 
-    def postinit(self, value=base.Empty):
+    def __init__(self, value, lineno=None, col_offset=None):
         self.value = value
+        super(Return, self).__init__(lineno, col_offset)
 
 
 class Set(BaseContainer):
@@ -676,10 +652,11 @@ class Slice(base.BaseNode):
     upper = base.Empty
     step = base.Empty
 
-    def postinit(self, lower=base.Empty, upper=base.Empty, step=base.Empty):
+    def __init__(self, lower, upper, step, lineno=None, col_offset=None):
         self.lower = lower
         self.upper = upper
         self.step = step
+        super(Slice, self).__init__(lineno, col_offset)
 
 
 class Starred(base.BaseNode):
@@ -688,12 +665,10 @@ class Starred(base.BaseNode):
     _other_fields = ('ctx', )
     value = base.Empty
 
-    def __init__(self, ctx=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, ctx, value, lineno=None, col_offset=None):
         self.ctx = ctx
-        super(Starred, self).__init__(lineno=lineno, col_offset=col_offset, parent=parent)
-
-    def postinit(self, value=base.Empty):
         self.value = value
+        super(Starred, self).__init__(lineno=lineno, col_offset=col_offset)
 
 
 class Subscript(base.BaseNode):
@@ -703,13 +678,11 @@ class Subscript(base.BaseNode):
     value = base.Empty
     slice = base.Empty
 
-    def __init__(self, ctx=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, ctx, value, slice, lineno=None, col_offset=None):
         self.ctx = ctx
-        super(Subscript, self).__init__(lineno=lineno, col_offset=col_offset, parent=parent)
-
-    def postinit(self, value=base.Empty, slice=base.Empty):
         self.value = value
         self.slice = slice
+        super(Subscript, self).__init__(lineno=lineno, col_offset=col_offset)
 
 
 class TryExcept(base.BlockRangeMixIn, Statement):
@@ -719,10 +692,11 @@ class TryExcept(base.BlockRangeMixIn, Statement):
     handlers = base.Empty
     orelse = base.Empty
 
-    def postinit(self, body=base.Empty, handlers=base.Empty, orelse=base.Empty):
+    def __init__(self, body, handlers, orelse, lineno=None, col_offset=None):
         self.body = body
         self.handlers = handlers
         self.orelse = orelse
+        super(TryExcept, self).__init__(lineno, col_offset)
 
     def block_range(self, lineno):
         """handle block line numbers range for try/except statements"""
@@ -743,9 +717,10 @@ class TryFinally(base.BlockRangeMixIn, Statement):
     body = base.Empty
     finalbody = base.Empty
 
-    def postinit(self, body=base.Empty, finalbody=base.Empty):
+    def __init__(self, body, finalbody, lineno=None, col_offset=None):
         self.body = body
         self.finalbody = finalbody
+        super(TryFinally, self).__init__(lineno, col_offset)
 
     def block_range(self, lineno):
         """handle block line numbers range for try/finally statements"""
@@ -761,9 +736,9 @@ class Tuple(BaseContainer):
 
     _other_fields = ('ctx',)
 
-    def __init__(self, ctx=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, ctx, elts, lineno=None, col_offset=None):
         self.ctx = ctx
-        super(Tuple, self).__init__(lineno, col_offset, parent)
+        super(Tuple, self).__init__(elts, lineno, col_offset)
 
 
 class UnaryOp(base.BaseNode):
@@ -772,12 +747,10 @@ class UnaryOp(base.BaseNode):
     _other_fields = ('op',)
     operand = base.Empty
 
-    def __init__(self, op=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, op, operand, lineno=None, col_offset=None):
         self.op = op
-        super(UnaryOp, self).__init__(lineno, col_offset, parent)
-
-    def postinit(self, operand=base.Empty):
         self.operand = operand
+        super(UnaryOp, self).__init__(lineno, col_offset)
 
 
 class While(base.BlockRangeMixIn, Statement):
@@ -787,10 +760,11 @@ class While(base.BlockRangeMixIn, Statement):
     body = base.Empty
     orelse = base.Empty
 
-    def postinit(self, test=base.Empty, body=base.Empty, orelse=base.Empty):
+    def __init__(self, test, body, orelse, lineno=None, col_offset=None):
         self.test = test
         self.body = body
         self.orelse = orelse
+        super(While, self).__init__(lineno, col_offset)
 
     @property
     def blockstart_tolineno(self):
@@ -805,14 +779,10 @@ class With(base.BlockRangeMixIn, Statement):
 
     _astroid_fields = ('items', 'body')
 
-    def __init__(self, lineno=None, col_offset=None, parent=None):
-        self.items = []
-        self.body = []
-        super(With, self).__init__(lineno, col_offset, parent)
-
-    def postinit(self, items=base.Empty, body=base.Empty):
+    def __init__(self, items, body, lineno=None, col_offset=None):
         self.items = items
         self.body = body
+        super(With, self).__init__(lineno, col_offset)
 
     @property
     def blockstart_tolineno(self):
@@ -824,9 +794,10 @@ class WithItem(base.BaseNode):
     context_expr = base.Empty
     optional_vars = base.Empty
 
-    def postinit(self, context_expr=base.Empty, optional_vars=base.Empty):
+    def __init__(self, context_expr, optional_vars, lineno=None, col_offset=None):
         self.context_expr = context_expr
         self.optional_vars = optional_vars
+        super(WithItem, self).__init__(lineno, col_offset)
 
 
 class AsyncWith(With):
@@ -838,8 +809,9 @@ class Yield(base.BaseNode):
     _astroid_fields = ('value',)
     value = base.Empty
 
-    def postinit(self, value=base.Empty):
+    def __init__(self, value, lineno=None, col_offset=None):
         self.value = value
+        super(Yield, self).__init__(lineno, col_offset)
 
 
 class YieldFrom(Yield):
@@ -864,17 +836,14 @@ class Module(base.BaseNode):
         _other_fields = ('name', 'doc', 'package', 'pure_python',
                          'source_code', 'source_file')
 
-    def __init__(self, name, doc, package=None, pure_python=True, source_code=None, source_file=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, name, doc, file_encoding, package, pure_python, source_code, source_file, body, lineno=None, col_offset=None):
         self.name = name
         self.doc = doc
+        self.file_encoding = file_encoding
         self.package = package
-        self.parent = parent
         self.pure_python = pure_python
         self.source_code = source_code
         self.source_file = source_file
-        self.body = []
-
-    def postinit(self, body=()):
         self.body = body
 
     @property
@@ -970,12 +939,10 @@ class BaseComprehension(base.BaseNode):
     elt = base.Empty
     generators = base.Empty
 
-    def postinit(self, generators=base.Empty, elt=base.Empty):
-        if generators is base.Empty:
-            self.generators = []
-        else:
-            self.generators = generators
+    def __init__(self, generators, elt, lineno=None, col_offset=None):
+        self.generators = generators
         self.elt = elt
+        super(BaseComprehension, self).__init__(lineno, col_offset)
 
 
 class GeneratorExp(BaseComprehension):
@@ -987,13 +954,15 @@ class DictComp(BaseComprehension):
     key = base.Empty
     value = base.Empty
 
-    def postinit(self, generators=base.Empty, key=base.Empty, value=base.Empty):
-        if generators is base.Empty:
-            self.generators = []
-        else:
-            self.generators = generators
+    def __init__(self, generators, key, value, lineno=None, col_offset=None):
+        self.generators = generators
         self.key = key
         self.value = value
+        # TODO: figure out a better solution here to inheritance for DictComp.
+        
+        # super(DictComp, self).__init__(lineno, col_offset)
+        self.lineno = lineno
+        self.col_offset = col_offset
 
 
 class SetComp(BaseComprehension):
@@ -1005,9 +974,15 @@ class _ListComp(base.BaseNode):
     elt = base.Empty
     generators = base.Empty
 
-    def postinit(self, generators=base.Empty, elt=base.Empty):
+    def __init__(self, generators, elt, lineno=None, col_offset=None):
         self.generators = generators
         self.elt = elt
+        # TODO: figure out a better solution here to inheritance for ListComp.
+
+        # super(_ListComp, self).__init__(lineno, col_offset)
+        self.lineno = lineno
+        self.col_offset = col_offset
+
 
 if six.PY3:
     class ListComp(_ListComp, BaseComprehension):
@@ -1052,14 +1027,10 @@ class Lambda(LambdaFunctionMixin):
     _other_fields = ('name',)
     name = '<lambda>'
 
-    def __init__(self, lineno=None, col_offset=None, parent=None):
-        self.args = []
-        self.body = []
-        super(Lambda, self).__init__(lineno, col_offset, parent)
-
-    def postinit(self, args, body):
+    def __init__(self, args, body, lineno=None, col_offset=None):
         self.args = args
         self.body = body
+        super(Lambda, self).__init__(lineno, col_offset)
 
 
 class FunctionDef(LambdaFunctionMixin, Statement):
@@ -1068,16 +1039,14 @@ class FunctionDef(LambdaFunctionMixin, Statement):
     _other_fields = ('name', 'doc')
     decorators = base.Empty
 
-    def __init__(self, name=None, doc=None, lineno=None, col_offset=None, parent=None):
+    def __init__(self, name, doc, args, body, decorators, returns, lineno=None, col_offset=None):
         self.name = name
         self.doc = doc
-        super(FunctionDef, self).__init__(lineno, col_offset, parent)
-
-    def postinit(self, args, body, decorators=base.Empty, returns=base.Empty):
         self.args = args
         self.body = body
         self.decorators = decorators
         self.returns = returns
+        super(FunctionDef, self).__init__(lineno, col_offset)
 
     @property
     def fromlineno(self):
@@ -1124,18 +1093,14 @@ class ClassDef(Statement):
     _other_fields = ('name', 'doc')
     decorators = base.Empty
 
-    def __init__(self, name=None, doc=None, lineno=None, col_offset=None, parent=None):
-        self.bases = []
-        self.body = []
+    def __init__(self, name, doc, bases, body, decorators, keywords, lineno=None, col_offset=None):
         self.name = name
         self.doc = doc
-        super(ClassDef, self).__init__(lineno, col_offset, parent)
-
-    def postinit(self, bases, body=[], decorators=[], keywords=[]):
         self.bases = bases
         self.body = body
         self.decorators = decorators
         self.keywords = keywords
+        super(ClassDef, self).__init__(lineno, col_offset)
 
     @property
     def blockstart_tolineno(self):

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -26,69 +26,75 @@ import sys
 import astroid
 from astroid import nodes
 
-
-_BIN_OP_CLASSES = {ast.Add: '+',
-                   ast.BitAnd: '&',
-                   ast.BitOr: '|',
-                   ast.BitXor: '^',
-                   ast.Div: '/',
-                   ast.FloorDiv: '//',
-                   ast.Mod: '%',
-                   ast.Mult: '*',
-                   ast.Pow: '**',
-                   ast.Sub: '-',
-                   ast.LShift: '<<',
-                   ast.RShift: '>>',
-                  }
+_BIN_OP_CLASSES = {
+    ast.Add: '+',
+    ast.BitAnd: '&',
+    ast.BitOr: '|',
+    ast.BitXor: '^',
+    ast.Div: '/',
+    ast.FloorDiv: '//',
+    ast.Mod: '%',
+    ast.Mult: '*',
+    ast.Pow: '**',
+    ast.Sub: '-',
+    ast.LShift: '<<',
+    ast.RShift: '>>',
+}
 if sys.version_info >= (3, 5):
     _BIN_OP_CLASSES[ast.MatMult] = '@'
 
-_BOOL_OP_CLASSES = {ast.And: 'and',
-                    ast.Or: 'or',
-                   }
+_BOOL_OP_CLASSES = {ast.And: 'and', ast.Or: 'or', }
 
-_UNARY_OP_CLASSES = {ast.UAdd: '+',
-                     ast.USub: '-',
-                     ast.Not: 'not',
-                     ast.Invert: '~',
-                    }
+_UNARY_OP_CLASSES = {
+    ast.UAdd: '+',
+    ast.USub: '-',
+    ast.Not: 'not',
+    ast.Invert: '~',
+}
 
-_CMP_OP_CLASSES = {ast.Eq: '==',
-                   ast.Gt: '>',
-                   ast.GtE: '>=',
-                   ast.In: 'in',
-                   ast.Is: 'is',
-                   ast.IsNot: 'is not',
-                   ast.Lt: '<',
-                   ast.LtE: '<=',
-                   ast.NotEq: '!=',
-                   ast.NotIn: 'not in',
-                  }
+_CMP_OP_CLASSES = {
+    ast.Eq: '==',
+    ast.Gt: '>',
+    ast.GtE: '>=',
+    ast.In: 'in',
+    ast.Is: 'is',
+    ast.IsNot: 'is not',
+    ast.Lt: '<',
+    ast.LtE: '<=',
+    ast.NotEq: '!=',
+    ast.NotIn: 'not in',
+}
 
 # Ellipsis is also one of these but has its own node
-BUILTIN_NAMES = {'None': None,
-                 'NotImplemented': NotImplemented,
-                 'True': True,
-                 'False': False}
+BUILTIN_NAMES = {
+    'None': None,
+    'NotImplemented': NotImplemented,
+    'True': True,
+    'False': False
+}
 
-REDIRECT = {'arguments': 'Arguments',
-            'comprehension': 'Comprehension',
-            "ListCompFor": 'Comprehension',
-            "GenExprFor": 'Comprehension',
-            'excepthandler': 'ExceptHandler',
-            'keyword': 'Keyword',
-           }
+REDIRECT = {
+    'arguments': 'Arguments',
+    'comprehension': 'Comprehension',
+    "ListCompFor": 'Comprehension',
+    "GenExprFor": 'Comprehension',
+    'excepthandler': 'ExceptHandler',
+    'keyword': 'Keyword',
+}
 PY3 = sys.version_info >= (3, 0)
 PY34 = sys.version_info >= (3, 4)
-CONTEXTS = {ast.Load: astroid.Load,
-            ast.Store: astroid.Store,
-            ast.Del: astroid.Del,
-            ast.Param: astroid.Store}
+CONTEXTS = {
+    ast.Load: astroid.Load,
+    ast.Store: astroid.Store,
+    ast.Del: astroid.Del,
+    ast.Param: astroid.Store
+}
 
 
 def _get_doc(node):
     try:
-        if isinstance(node.body[0], ast.Expr) and isinstance(node.body[0].value, ast.Str):
+        if isinstance(node.body[0],
+                      ast.Expr) and isinstance(node.body[0].value, ast.Str):
             doc = node.body[0].value.s
             node.body = node.body[1:]
             return node, doc
@@ -96,6 +102,7 @@ def _get_doc(node):
             return node, None
     except IndexError:
         return node, None
+
 
 def _visit_or_empty(node, attr, visitor, visit='visit', **kws):
     """If the given node has an attribute, visits the attribute, and
@@ -123,7 +130,7 @@ class ParameterVisitor(object):
         cls_name = param_node.__class__.__name__
         visit_name = 'visit_' + REDIRECT.get(cls_name, cls_name).lower()
         visit_method = getattr(self, visit_name)
-        return visit_method(param_node, *args) 
+        return visit_method(param_node, *args)
 
     def visit_arg(self, param_node, *args):
         name = param_node.arg
@@ -140,7 +147,11 @@ class ParameterVisitor(object):
         # so it's possible to be broken.
         converted_node = self._visitor.visit(param_node)
         for element in converted_node.elts:
-            param = nodes.Parameter(name=element.name, default=default, annotation=nodes.Empty, lineno=param_node.lineno, col_offset=param_node.col_offset)
+            param = nodes.Parameter(name=element.name,
+                                    default=default,
+                                    annotation=nodes.Empty,
+                                    lineno=param_node.lineno,
+                                    col_offset=param_node.col_offset)
             yield param
 
     def _build_parameter(self, param_node, name, default):
@@ -149,9 +160,13 @@ class ParameterVisitor(object):
         if param_annotation:
             annotation = self._visitor.visit(param_annotation)
 
-        param = nodes.Parameter(name=name, default=default, annotation=annotation, lineno=getattr(param_node, 'lineno', None), col_offset=getattr(param_node, 'col_offset', None))
+        param = nodes.Parameter(
+            name=name,
+            default=default,
+            annotation=annotation,
+            lineno=getattr(param_node, 'lineno', None),
+            col_offset=getattr(param_node, 'col_offset', None))
         yield param
-
 
 
 class TreeRebuilder(object):
@@ -164,7 +179,14 @@ class TreeRebuilder(object):
     def visit_module(self, node, modname, modpath, package):
         """visit a Module node by returning a fresh instance of it"""
         node, doc = _get_doc(node)
-        newnode = nodes.Module(name=modname, doc=doc, file_encoding='???', package=package, pure_python=True, source_code='???', source_file=modpath, body=[self.visit(child) for child in node.body])
+        newnode = nodes.Module(name=modname,
+                               doc=doc,
+                               file_encoding='???',
+                               package=package,
+                               pure_python=True,
+                               source_code='???',
+                               source_file=modpath,
+                               body=[self.visit(child) for child in node.body])
         return newnode
 
     def visit(self, node):
@@ -180,6 +202,7 @@ class TreeRebuilder(object):
 
     def visit_arguments(self, node):
         """visit a Arguments node by returning a fresh instance of it"""
+
         def _build_variadic(field_name):
             param = nodes.Empty
             variadic = getattr(node, field_name)
@@ -197,15 +220,19 @@ class TreeRebuilder(object):
                 # Get the annotation of the variadic node.
                 annotation = nodes.Empty
                 default = nodes.Empty
-                variadic_annotation = getattr(variadic, 'annotation', nodes.Empty)
+                variadic_annotation = getattr(variadic, 'annotation',
+                                              nodes.Empty)
                 if variadic_annotation is None:
                     # Support for Python 3.3.
-                    variadic_annotation = getattr(node, field_name + 'annotation', nodes.Empty)
+                    variadic_annotation = getattr(
+                        node, field_name + 'annotation', nodes.Empty)
                 if variadic_annotation:
                     annotation = self.visit(variadic_annotation)
 
                 # TODO: fix lineno and col_offset, see #335.
-                param = nodes.Parameter(name=param_name, default=default, annotation=annotation)
+                param = nodes.Parameter(name=param_name,
+                                        default=default,
+                                        annotation=annotation)
             return param
 
         def _build_args(params, defaults):
@@ -226,12 +253,16 @@ class TreeRebuilder(object):
         # Build the arguments list.
         positional_args = list(_build_args(node.args, node.defaults))
         kwonlyargs = list(_build_args(getattr(node, 'kwonlyargs', ()),
-                                              getattr(node, 'kw_defaults', ())))
+                                      getattr(node, 'kw_defaults', ())))
         # Build vararg and kwarg.
         vararg = _build_variadic('vararg')
         kwarg = _build_variadic('kwarg')
         # Prepare the arguments new node.
-        newnode = nodes.Arguments(args=positional_args, vararg=vararg, kwarg=kwarg, keyword_only=kwonlyargs, positional_only=[])
+        newnode = nodes.Arguments(args=positional_args,
+                                  vararg=vararg,
+                                  kwarg=kwarg,
+                                  keyword_only=kwonlyargs,
+                                  positional_only=[])
         return newnode
 
     def visit_assert(self, node):
@@ -240,118 +271,168 @@ class TreeRebuilder(object):
             msg = self.visit(node.msg)
         else:
             msg = nodes.Empty
-        newnode = nodes.Assert(test=self.visit(node.test), fail=msg, lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Assert(test=self.visit(node.test),
+                               fail=msg,
+                               lineno=node.lineno,
+                               col_offset=node.col_offset)
         return newnode
 
     def visit_assign(self, node):
         """visit a Assign node by returning a fresh instance of it"""
-        newnode = nodes.Assign(targets=[self.visit(child)
-                          for child in node.targets], value=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Assign(
+            targets=[self.visit(child) for child in node.targets],
+            value=self.visit(node.value),
+            lineno=node.lineno,
+            col_offset=node.col_offset)
         return newnode
 
     def visit_assignname(self, node, node_name=None):
         '''visit a node and return a AssignName node'''
-        newnode = nodes.AssignName(name=node_name, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
+        newnode = nodes.AssignName(
+            name=node_name,
+            lineno=getattr(node, 'lineno', None),
+            col_offset=getattr(node, 'col_offset', None))
         return newnode
 
     def visit_augassign(self, node):
         """visit a AugAssign node by returning a fresh instance of it"""
-        newnode = nodes.AugAssign(op=_BIN_OP_CLASSES[type(node.op)] + "=", target=self.visit(node.target), value=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.AugAssign(op=_BIN_OP_CLASSES[type(node.op)] + "=",
+                                  target=self.visit(node.target),
+                                  value=self.visit(node.value),
+                                  lineno=node.lineno,
+                                  col_offset=node.col_offset)
         return newnode
 
     def visit_repr(self, node):
         """visit a Backquote node by returning a fresh instance of it"""
-        newnode = nodes.Repr(value=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Repr(value=self.visit(node.value),
+                             lineno=node.lineno,
+                             col_offset=node.col_offset)
         return newnode
 
     def visit_binop(self, node):
         """visit a BinOp node by returning a fresh instance of it"""
-        newnode = nodes.BinOp(op=_BIN_OP_CLASSES[type(node.op)], left=self.visit(node.left), right=self.visit(node.right), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.BinOp(op=_BIN_OP_CLASSES[type(node.op)],
+                              left=self.visit(node.left),
+                              right=self.visit(node.right),
+                              lineno=node.lineno,
+                              col_offset=node.col_offset)
         return newnode
 
     def visit_boolop(self, node):
         """visit a BoolOp node by returning a fresh instance of it"""
-        newnode = nodes.BoolOp(op=_BOOL_OP_CLASSES[type(node.op)], values=[self.visit(child)
-                          for child in node.values], lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.BoolOp(
+            op=_BOOL_OP_CLASSES[type(node.op)],
+            values=[self.visit(child) for child in node.values],
+            lineno=node.lineno,
+            col_offset=node.col_offset)
         return newnode
 
     def visit_break(self, node):
         """visit a Break node by returning a fresh instance of it"""
-        return nodes.Break(lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
+        return nodes.Break(lineno=getattr(node, 'lineno', None),
+                           col_offset=getattr(node, 'col_offset', None))
 
     def visit_call(self, node):
         """visit a CallFunc node by returning a fresh instance of it"""
         starargs = _visit_or_empty(node, 'starargs', self)
         kwargs = _visit_or_empty(node, 'kwargs', self)
-        args = [self.visit(child)
-                for child in node.args]
+        args = [self.visit(child) for child in node.args]
 
         if node.keywords:
-            keywords = [self.visit(child)
-                        for child in node.keywords]
+            keywords = [self.visit(child) for child in node.keywords]
         else:
             keywords = ()
         if starargs:
-            new_starargs = nodes.Starred(value=starargs, ctx=starargs.col_offset, lineno=starargs.lineno)
+            new_starargs = nodes.Starred(value=starargs,
+                                         ctx=starargs.col_offset,
+                                         lineno=starargs.lineno)
             args.append(new_starargs)
         if kwargs:
-            new_kwargs = nodes.Keyword(arg=None, value=kwargs, lineno=kwargs.col_offset, col_offset=kwargs.lineno)
+            new_kwargs = nodes.Keyword(arg=None,
+                                       value=kwargs,
+                                       lineno=kwargs.col_offset,
+                                       col_offset=kwargs.lineno)
             if keywords:
                 keywords.append(new_kwargs)
             else:
                 keywords = [new_kwargs]
 
-        
-        newnode = nodes.Call(func=self.visit(node.func), args=args, keywords=keywords, lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Call(func=self.visit(node.func),
+                             args=args,
+                             keywords=keywords,
+                             lineno=node.lineno,
+                             col_offset=node.col_offset)
         return newnode
 
-    def visit_classdef(self, node): # , newstyle=None):
+    def visit_classdef(self, node):  # , newstyle=None):
         """visit a ClassDef node to become astroid"""
         node, doc = _get_doc(node)
         if PY3:
-            keywords = [self.visit_keyword(keyword) for keyword in node.keywords]
+            keywords = [self.visit_keyword(keyword)
+                        for keyword in node.keywords]
         else:
             keywords = []
         if node.decorator_list:
             decorators = self.visit_decorators(node)
         else:
             decorators = []
-        newnode = nodes.ClassDef(name=node.name, doc=doc, bases=[self.visit(child) for child in node.bases], body=[self.visit(child) for child in node.body], decorators=decorators, keywords=keywords, lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.ClassDef(
+            name=node.name,
+            doc=doc,
+            bases=[self.visit(child) for child in node.bases],
+            body=[self.visit(child) for child in node.body],
+            decorators=decorators,
+            keywords=keywords,
+            lineno=node.lineno,
+            col_offset=node.col_offset)
         return newnode
 
     def visit_const(self, node):
         """visit a Const node by returning a fresh instance of it"""
-        return nodes.Const(value=node.value, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
+        return nodes.Const(value=node.value,
+                           lineno=getattr(node, 'lineno', None),
+                           col_offset=getattr(node, 'col_offset', None))
 
     def visit_continue(self, node):
         """visit a Continue node by returning a fresh instance of it"""
-        return nodes.Continue(lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
+        return nodes.Continue(lineno=getattr(node, 'lineno', None),
+                              col_offset=getattr(node, 'col_offset', None))
 
     def visit_compare(self, node):
         """visit a Compare node by returning a fresh instance of it"""
-        newnode = nodes.Compare(ops=[_CMP_OP_CLASSES[type(op)] for op in
-                                 node.ops], left=self.visit(node.left), comparators=[self.visit(expr)
-                          for expr in node.comparators], lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Compare(
+            ops=[_CMP_OP_CLASSES[type(op)] for op in node.ops],
+            left=self.visit(node.left),
+            comparators=[self.visit(expr) for expr in node.comparators],
+            lineno=node.lineno,
+            col_offset=node.col_offset)
         return newnode
 
     def visit_comprehension(self, node):
         """visit a Comprehension node by returning a fresh instance of it"""
-        newnode = nodes.Comprehension(target=self.visit(node.target), iter=self.visit(node.iter), ifs=[self.visit(child)
-                          for child in node.ifs])
+        newnode = nodes.Comprehension(
+            target=self.visit(node.target),
+            iter=self.visit(node.iter),
+            ifs=[self.visit(child) for child in node.ifs])
         return newnode
 
     def visit_decorators(self, node):
         """visit a Decorators node by returning a fresh instance of it"""
         # /!\ node is actually a ast.FunctionDef node while
         # parent is a astroid.nodes.FunctionDef node
-        newnode = nodes.Decorators(nodes=[self.visit(child)
-                          for child in node.decorator_list], lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Decorators(
+            nodes=[self.visit(child) for child in node.decorator_list],
+            lineno=node.lineno,
+            col_offset=node.col_offset)
         return newnode
 
     def visit_delete(self, node):
         """visit a Delete node by returning a fresh instance of it"""
-        newnode = nodes.Delete(targets=[self.visit(child)
-                          for child in node.targets], lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Delete(
+            targets=[self.visit(child) for child in node.targets],
+            lineno=node.lineno,
+            col_offset=node.col_offset)
         return newnode
 
     def _visit_dict_items(self, node):
@@ -359,7 +440,9 @@ class TreeRebuilder(object):
             rebuilt_value = self.visit(value)
             if not key:
                 # Python 3.5 and extended unpacking
-                rebuilt_key = nodes.DictUnpack(lineno=rebuilt_value.lineno, col_offset=rebuilt_value.col_offset)
+                rebuilt_key = nodes.DictUnpack(
+                    lineno=rebuilt_value.lineno,
+                    col_offset=rebuilt_value.col_offset)
             else:
                 rebuilt_key = self.visit(key)
             yield rebuilt_key, rebuilt_value
@@ -371,38 +454,52 @@ class TreeRebuilder(object):
             keys, values = zip(*items)
         else:
             keys, values = [], []
-        newnode = nodes.Dict(keys=keys, values=values, lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Dict(keys=keys,
+                             values=values,
+                             lineno=node.lineno,
+                             col_offset=node.col_offset)
         return newnode
 
     def visit_dictcomp(self, node):
         """visit a DictComp node by returning a fresh instance of it"""
-        newnode = nodes.DictComp(generators=[self.visit(child) for
-                                             child in node.generators],
-                                 key=self.visit(node.key),
-                                 value=self.visit(node.value),
-                                 lineno=node.lineno,
-                                 col_offset=node.col_offset)
+        newnode = nodes.DictComp(
+            generators=[self.visit(child) for child in node.generators],
+            key=self.visit(node.key),
+            value=self.visit(node.value),
+            lineno=node.lineno,
+            col_offset=node.col_offset)
         return newnode
 
     def visit_expr(self, node):
         """visit a Expr node by returning a fresh instance of it"""
-        newnode = nodes.Expr(value=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Expr(value=self.visit(node.value),
+                             lineno=node.lineno,
+                             col_offset=node.col_offset)
         return newnode
 
     def visit_ellipsis(self, node):
         """visit an Ellipsis node by returning a fresh instance of it"""
-        return nodes.Ellipsis(lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
+        return nodes.Ellipsis(lineno=getattr(node, 'lineno', None),
+                              col_offset=getattr(node, 'col_offset', None))
 
     def visit_excepthandler(self, node):
         """visit an ExceptHandler node by returning a fresh instance of it"""
         # /!\ node.name can be a tuple
-        newnode = nodes.ExceptHandler(type=_visit_or_empty(node, 'type', self), name=_visit_or_empty(node, 'name', self), body=[self.visit(child)
-                          for child in node.body], lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.ExceptHandler(
+            type=_visit_or_empty(node, 'type', self),
+            name=_visit_or_empty(node, 'name', self),
+            body=[self.visit(child) for child in node.body],
+            lineno=node.lineno,
+            col_offset=node.col_offset)
         return newnode
 
     def visit_exec(self, node):
         """visit an Exec node by returning a fresh instance of it"""
-        newnode = nodes.Exec(expr=self.visit(node.body), globals=_visit_or_empty(node, 'globals', self), locals=_visit_or_empty(node, 'locals', self), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Exec(expr=self.visit(node.body),
+                             globals=_visit_or_empty(node, 'globals', self),
+                             locals=_visit_or_empty(node, 'locals', self),
+                             lineno=node.lineno,
+                             col_offset=node.col_offset)
         return newnode
 
     def visit_extslice(self, node):
@@ -414,11 +511,10 @@ class TreeRebuilder(object):
         """visit a For node by returning a fresh instance of it"""
         newnode = cls(target=self.visit(node.target),
                       iter=self.visit(node.iter),
-                      body=[self.visit(child)
-                          for child in node.body],
-                      orelse=[self.visit(child)
-                              for child in node.orelse],
-                      lineno=node.lineno, col_offset=node.col_offset)
+                      body=[self.visit(child) for child in node.body],
+                      orelse=[self.visit(child) for child in node.orelse],
+                      lineno=node.lineno,
+                      col_offset=node.col_offset)
         return newnode
 
     def visit_for(self, node):
@@ -427,7 +523,12 @@ class TreeRebuilder(object):
     def visit_importfrom(self, node):
         """visit an ImportFrom node by returning a fresh instance of it"""
         names = [(alias.name, alias.asname) for alias in node.names]
-        newnode = nodes.ImportFrom(modname=node.module or '', names=names, level=node.level or None, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
+        newnode = nodes.ImportFrom(
+            modname=node.module or '',
+            names=names,
+            level=node.level or None,
+            lineno=getattr(node, 'lineno', None),
+            col_offset=getattr(node, 'col_offset', None))
         return newnode
 
     def _visit_functiondef(self, cls, node):
@@ -442,12 +543,14 @@ class TreeRebuilder(object):
             returns = self.visit(node.returns)
         else:
             returns = nodes.Empty
-        newnode = cls(name=node.name, doc=doc,
+        newnode = cls(name=node.name,
+                      doc=doc,
                       args=self.visit(node.args),
-                      body=[self.visit(child)
-                            for child in node.body],
-                      decorators=decorators, returns=returns,
-                      lineno=node.lineno, col_offset=node.col_offset)
+                      body=[self.visit(child) for child in node.body],
+                      decorators=decorators,
+                      returns=returns,
+                      lineno=node.lineno,
+                      col_offset=node.col_offset)
         self._global_names.pop()
         return newnode
 
@@ -456,8 +559,11 @@ class TreeRebuilder(object):
 
     def visit_generatorexp(self, node):
         """visit a GeneratorExp node by returning a fresh instance of it"""
-        newnode = nodes.GeneratorExp(generators=[self.visit(child)
-                          for child in node.generators], elt=self.visit(node.elt), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.GeneratorExp(
+            generators=[self.visit(child) for child in node.generators],
+            elt=self.visit(node.elt),
+            lineno=node.lineno,
+            col_offset=node.col_offset)
         return newnode
 
     def visit_attribute(self, node):
@@ -466,37 +572,56 @@ class TreeRebuilder(object):
         # FIXME : maybe we should reintroduce and visit_delattr ?
         # for instance, deactivating assign_ctx
         if context == astroid.Del:
-            newnode = nodes.DelAttr(attrname=node.attr, expr=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
+            newnode = nodes.DelAttr(attrname=node.attr,
+                                    expr=self.visit(node.value),
+                                    lineno=node.lineno,
+                                    col_offset=node.col_offset)
         elif context == astroid.Store:
-            newnode = nodes.AssignAttr(attrname=node.attr, expr=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
+            newnode = nodes.AssignAttr(attrname=node.attr,
+                                       expr=self.visit(node.value),
+                                       lineno=node.lineno,
+                                       col_offset=node.col_offset)
         else:
-            newnode = nodes.Attribute(attrname=node.attr, expr=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
+            newnode = nodes.Attribute(attrname=node.attr,
+                                      expr=self.visit(node.value),
+                                      lineno=node.lineno,
+                                      col_offset=node.col_offset)
         return newnode
 
     def visit_global(self, node):
         """visit a Global node to become astroid"""
-        newnode = nodes.Global(names=node.names, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
-        if self._global_names: # global at the module level, no effect
+        newnode = nodes.Global(names=node.names,
+                               lineno=getattr(node, 'lineno', None),
+                               col_offset=getattr(node, 'col_offset', None))
+        if self._global_names:  # global at the module level, no effect
             for name in node.names:
                 self._global_names[-1].setdefault(name, []).append(newnode)
         return newnode
 
     def visit_if(self, node):
         """visit an If node by returning a fresh instance of it"""
-        newnode = nodes.If(test=self.visit(node.test), body=[self.visit(child)
-                          for child in node.body], orelse=[self.visit(child)
-                          for child in node.orelse], lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.If(test=self.visit(node.test),
+                           body=[self.visit(child) for child in node.body],
+                           orelse=[self.visit(child) for child in node.orelse],
+                           lineno=node.lineno,
+                           col_offset=node.col_offset)
         return newnode
 
     def visit_ifexp(self, node):
         """visit a IfExp node by returning a fresh instance of it"""
-        newnode = nodes.IfExp(test=self.visit(node.test), body=self.visit(node.body), orelse=self.visit(node.orelse), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.IfExp(test=self.visit(node.test),
+                              body=self.visit(node.body),
+                              orelse=self.visit(node.orelse),
+                              lineno=node.lineno,
+                              col_offset=node.col_offset)
         return newnode
 
     def visit_import(self, node):
         """visit a Import node by returning a fresh instance of it"""
         names = [(alias.name, alias.asname) for alias in node.names]
-        newnode = nodes.Import(names=names, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
+        newnode = nodes.Import(names=names,
+                               lineno=getattr(node, 'lineno', None),
+                               col_offset=getattr(node, 'col_offset', None))
         return newnode
 
     def visit_index(self, node):
@@ -521,16 +646,18 @@ class TreeRebuilder(object):
         """visit a List node by returning a fresh instance of it"""
         context = _get_context(node)
         newnode = nodes.List(ctx=context,
-                             elts=[self.visit(child)
-                              for child in node.elts],
+                             elts=[self.visit(child) for child in node.elts],
                              lineno=node.lineno,
                              col_offset=node.col_offset)
         return newnode
 
     def visit_listcomp(self, node):
         """visit a ListComp node by returning a fresh instance of it"""
-        newnode = nodes.ListComp(generators=[self.visit(child)
-                          for child in node.generators], elt=self.visit(node.elt), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.ListComp(
+            generators=[self.visit(child) for child in node.generators],
+            elt=self.visit(node.elt),
+            lineno=node.lineno,
+            col_offset=node.col_offset)
         return newnode
 
     def visit_name(self, node):
@@ -539,24 +666,38 @@ class TreeRebuilder(object):
         # True and False can be assigned to something in py2x, so we have to
         # check first the context.
         if context == astroid.Del:
-            newnode = nodes.DelName(name=node.id, lineno=node.lineno, col_offset=node.col_offset)
+            newnode = nodes.DelName(name=node.id,
+                                    lineno=node.lineno,
+                                    col_offset=node.col_offset)
         elif context == astroid.Store:
-            newnode = nodes.AssignName(name=node.id, lineno=node.lineno, col_offset=node.col_offset)
+            newnode = nodes.AssignName(name=node.id,
+                                       lineno=node.lineno,
+                                       col_offset=node.col_offset)
         elif node.id in BUILTIN_NAMES:
-            newnode = nodes.NameConstant(value=BUILTIN_NAMES[node.id], lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
+            newnode = nodes.NameConstant(
+                value=BUILTIN_NAMES[node.id],
+                lineno=getattr(node, 'lineno', None),
+                col_offset=getattr(node, 'col_offset', None))
             return newnode
         else:
-            newnode = nodes.Name(name=node.id, lineno=node.lineno, col_offset=node.col_offset)
+            newnode = nodes.Name(name=node.id,
+                                 lineno=node.lineno,
+                                 col_offset=node.col_offset)
         return newnode
 
     def visit_str(self, node):
         """visit a String/Bytes node by returning a fresh instance of Const"""
-        return nodes.Const(value=node.s, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
+        return nodes.Const(value=node.s,
+                           lineno=getattr(node, 'lineno', None),
+                           col_offset=getattr(node, 'col_offset', None))
+
     visit_bytes = visit_str
 
     def visit_num(self, node):
         """visit a Num node by returning a fresh instance of Const"""
-        return nodes.Const(value=node.n, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
+        return nodes.Const(value=node.n,
+                           lineno=getattr(node, 'lineno', None),
+                           col_offset=getattr(node, 'col_offset', None))
 
     def visit_pass(self, node):
         """visit a Pass node by returning a fresh instance of it"""
@@ -564,91 +705,127 @@ class TreeRebuilder(object):
 
     def visit_print(self, node):
         """visit a Print node by returning a fresh instance of it"""
-        newnode = nodes.Print(nl=node.nl, dest=_visit_or_empty(node, 'dest', self), values=[self.visit(child)
-                          for child in node.values], lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Print(
+            nl=node.nl,
+            dest=_visit_or_empty(node, 'dest', self),
+            values=[self.visit(child) for child in node.values],
+            lineno=node.lineno,
+            col_offset=node.col_offset)
         return newnode
 
     def visit_raise(self, node):
         """visit a Raise node by returning a fresh instance of it"""
-        newnode = nodes.Raise(exc=_visit_or_empty(node, 'type', self), cause=_visit_or_empty(node, 'inst', self), traceback=_visit_or_empty(node, 'tback', self), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Raise(exc=_visit_or_empty(node, 'type', self),
+                              cause=_visit_or_empty(node, 'inst', self),
+                              traceback=_visit_or_empty(node, 'tback', self),
+                              lineno=node.lineno,
+                              col_offset=node.col_offset)
         return newnode
 
     def visit_return(self, node):
         """visit a Return node by returning a fresh instance of it"""
-        newnode = nodes.Return(value=_visit_or_empty(node, 'value', self), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Return(value=_visit_or_empty(node, 'value', self),
+                               lineno=node.lineno,
+                               col_offset=node.col_offset)
         return newnode
 
     def visit_set(self, node):
         """visit a Set node by returning a fresh instance of it"""
-        newnode = nodes.Set(elts=[self.visit(child) for child in
-                             node.elts], lineno=node.lineno,
+        newnode = nodes.Set(elts=[self.visit(child) for child in node.elts],
+                            lineno=node.lineno,
                             col_offset=node.col_offset)
         return newnode
 
     def visit_setcomp(self, node):
         """visit a SetComp node by returning a fresh instance of it"""
-        newnode = nodes.SetComp(generators=[self.visit(child)
-                          for child in node.generators], elt=self.visit(node.elt), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.SetComp(
+            generators=[self.visit(child) for child in node.generators],
+            elt=self.visit(node.elt),
+            lineno=node.lineno,
+            col_offset=node.col_offset)
         return newnode
 
     def visit_slice(self, node):
         """visit a Slice node by returning a fresh instance of it"""
-        newnode = nodes.Slice(lower=_visit_or_empty(node, 'lower', self), upper=_visit_or_empty(node, 'upper', self), step=_visit_or_empty(node, 'step', self))
+        newnode = nodes.Slice(lower=_visit_or_empty(node, 'lower', self),
+                              upper=_visit_or_empty(node, 'upper', self),
+                              step=_visit_or_empty(node, 'step', self))
         return newnode
 
     def visit_subscript(self, node):
         """visit a Subscript node by returning a fresh instance of it"""
         context = _get_context(node)
-        newnode = nodes.Subscript(ctx=context, value=self.visit(node.value), slice=self.visit(node.slice), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Subscript(ctx=context,
+                                  value=self.visit(node.value),
+                                  slice=self.visit(node.slice),
+                                  lineno=node.lineno,
+                                  col_offset=node.col_offset)
         return newnode
 
     def visit_tryexcept(self, node):
         """visit a TryExcept node by returning a fresh instance of it"""
-        newnode = nodes.TryExcept(body=[self.visit(child)
-                          for child in node.body], handlers=[self.visit(child)
-                          for child in node.handlers], orelse=[self.visit(child)
-                          for child in node.orelse], lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.TryExcept(
+            body=[self.visit(child) for child in node.body],
+            handlers=[self.visit(child) for child in node.handlers],
+            orelse=[self.visit(child) for child in node.orelse],
+            lineno=node.lineno,
+            col_offset=node.col_offset)
         return newnode
 
     def visit_tryfinally(self, node):
         """visit a TryFinally node by returning a fresh instance of it"""
-        newnode = nodes.TryFinally(body=[self.visit(child)
-                          for child in node.body], finalbody=[self.visit(n)
-                          for n in node.finalbody], lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.TryFinally(
+            body=[self.visit(child) for child in node.body],
+            finalbody=[self.visit(n) for n in node.finalbody],
+            lineno=node.lineno,
+            col_offset=node.col_offset)
         return newnode
 
     def visit_tuple(self, node):
         """visit a Tuple node by returning a fresh instance of it"""
         context = _get_context(node)
         newnode = nodes.Tuple(ctx=context,
-                              elts=[self.visit(child)
-                                    for child in node.elts],
+                              elts=[self.visit(child) for child in node.elts],
                               lineno=node.lineno,
                               col_offset=node.col_offset)
         return newnode
 
     def visit_unaryop(self, node):
         """visit a UnaryOp node by returning a fresh instance of it"""
-        newnode = nodes.UnaryOp(op=_UNARY_OP_CLASSES[node.op.__class__], operand=self.visit(node.operand), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.UnaryOp(op=_UNARY_OP_CLASSES[node.op.__class__],
+                                operand=self.visit(node.operand),
+                                lineno=node.lineno,
+                                col_offset=node.col_offset)
         return newnode
 
     def visit_while(self, node):
         """visit a While node by returning a fresh instance of it"""
-        newnode = nodes.While(test=self.visit(node.test), body=[self.visit(child)
-                          for child in node.body], orelse=[self.visit(child)
-                          for child in node.orelse], lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.While(
+            test=self.visit(node.test),
+            body=[self.visit(child) for child in node.body],
+            orelse=[self.visit(child) for child in node.orelse],
+            lineno=node.lineno,
+            col_offset=node.col_offset)
         return newnode
 
     def visit_with(self, node):
         context_expr = self.visit(node.context_expr)
         optional_vars = _visit_or_empty(node, 'optional_vars', self)
-        with_item = nodes.WithItem(context_expr=context_expr, optional_vars=optional_vars, lineno=node.context_expr.lineno, col_offset=node.context_expr.col_offset)
-        newnode = nodes.With(items=[with_item], body=[self.visit(child) for child in node.body], lineno=node.lineno, col_offset=node.col_offset)
+        with_item = nodes.WithItem(context_expr=context_expr,
+                                   optional_vars=optional_vars,
+                                   lineno=node.context_expr.lineno,
+                                   col_offset=node.context_expr.col_offset)
+        newnode = nodes.With(items=[with_item],
+                             body=[self.visit(child) for child in node.body],
+                             lineno=node.lineno,
+                             col_offset=node.col_offset)
         return newnode
 
     def visit_yield(self, node):
         """visit a Yield node by returning a fresh instance of it"""
-        newnode = nodes.Yield(value=_visit_or_empty(node, 'value', self), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Yield(value=_visit_or_empty(node, 'value', self),
+                              lineno=node.lineno,
+                              col_offset=node.col_offset)
         return newnode
 
 
@@ -657,7 +834,9 @@ class TreeRebuilder3(TreeRebuilder):
 
     def visit_nameconstant(self, node):
         # in Python 3.4 we have NameConstant for True / False / None
-        return nodes.NameConstant(value=node.value, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
+        return nodes.NameConstant(value=node.value,
+                                  lineno=getattr(node, 'lineno', None),
+                                  col_offset=getattr(node, 'col_offset', None))
 
     def visit_excepthandler(self, node):
         """visit an ExceptHandler node by returning a fresh instance of it"""
@@ -665,24 +844,36 @@ class TreeRebuilder3(TreeRebuilder):
             name = self.visit_assignname(node, node.name)
         else:
             name = nodes.Empty
-        newnode = nodes.ExceptHandler(type=_visit_or_empty(node, 'type', self), name=name, body=[self.visit(child)
-                          for child in node.body], lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.ExceptHandler(
+            type=_visit_or_empty(node, 'type', self),
+            name=name,
+            body=[self.visit(child) for child in node.body],
+            lineno=node.lineno,
+            col_offset=node.col_offset)
         return newnode
 
     def visit_nonlocal(self, node):
         """visit a Nonlocal node and return a new instance of it"""
-        return nodes.Nonlocal(names=node.names, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
-
+        return nodes.Nonlocal(names=node.names,
+                              lineno=getattr(node, 'lineno', None),
+                              col_offset=getattr(node, 'col_offset', None))
 
     def visit_raise(self, node):
         """visit a Raise node by returning a fresh instance of it"""
-        newnode = nodes.Raise(exc=_visit_or_empty(node, 'exc', self), cause=_visit_or_empty(node, 'cause', self), traceback=nodes.Empty, lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Raise(exc=_visit_or_empty(node, 'exc', self),
+                              cause=_visit_or_empty(node, 'cause', self),
+                              traceback=nodes.Empty,
+                              lineno=node.lineno,
+                              col_offset=node.col_offset)
         return newnode
 
     def visit_starred(self, node):
         """visit a Starred node and return a new instance of it"""
         context = _get_context(node)
-        newnode = nodes.Starred(ctx=context, value=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Starred(ctx=context,
+                                value=self.visit(node.value),
+                                lineno=node.lineno,
+                                col_offset=node.col_offset)
         return newnode
 
     def visit_try(self, node):
@@ -692,16 +883,21 @@ class TreeRebuilder3(TreeRebuilder):
             if node.handlers:
                 body = [self.visit_tryexcept(node)]
             else:
-                body = [self.visit(child)
-                        for child in node.body]
-            newnode = nodes.TryFinally(body=body, finalbody=[self.visit(n)
-                              for n in node.finalbody], lineno=node.lineno, col_offset=node.col_offset)
+                body = [self.visit(child) for child in node.body]
+            newnode = nodes.TryFinally(
+                body=body,
+                finalbody=[self.visit(n) for n in node.finalbody],
+                lineno=node.lineno,
+                col_offset=node.col_offset)
             return newnode
         elif node.handlers:
             return self.visit_tryexcept(node)
 
     def visit_with(self, node, constructor=nodes.With):
-        newnode = constructor(items=[self.visit(item) for item in node.items], body=[self.visit(child) for child in node.body], lineno=node.lineno, col_offset=node.col_offset)
+        newnode = constructor(items=[self.visit(item) for item in node.items],
+                              body=[self.visit(child) for child in node.body],
+                              lineno=node.lineno,
+                              col_offset=node.col_offset)
         return newnode
 
     def visit_withitem(self, node):
@@ -714,7 +910,9 @@ class TreeRebuilder3(TreeRebuilder):
         return newnode
 
     def visit_yieldfrom(self, node):
-        newnode = nodes.YieldFrom(value=_visit_or_empty(node, 'value', self), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.YieldFrom(value=_visit_or_empty(node, 'value', self),
+                                  lineno=node.lineno,
+                                  col_offset=node.col_offset)
         return newnode
 
     # Async structs added in Python 3.5
@@ -725,7 +923,9 @@ class TreeRebuilder3(TreeRebuilder):
         return self._visit_for(nodes.AsyncFor, node)
 
     def visit_await(self, node):
-        newnode = nodes.Await(value=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
+        newnode = nodes.Await(value=self.visit(node.value),
+                              lineno=node.lineno,
+                              col_offset=node.col_offset)
         return newnode
 
     def visit_asyncwith(self, node):

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -97,14 +97,14 @@ def _get_doc(node):
     except IndexError:
         return node, None
 
-def _visit_or_empty(node, attr, visitor, parent, visit='visit', **kws):
+def _visit_or_empty(node, attr, visitor, visit='visit', **kws):
     """If the given node has an attribute, visits the attribute, and
     otherwise returns None.
 
     """
     value = getattr(node, attr, None)
     if value:
-        return getattr(visitor, visit)(value, parent, **kws)
+        return getattr(visitor, visit)(value, **kws)
     else:
         return nodes.Empty
 
@@ -133,29 +133,23 @@ class ParameterVisitor(object):
         name = param_node.id
         return self._build_parameter(param_node, name, *args)
 
-    def visit_tuple(self, param_node, parent, default):
+    def visit_tuple(self, param_node, default):
         # We're not supporting nested arguments anymore, but in order to
         # simply not crash when running on Python 2, we're unpacking the elements
         # before hand. We simply don't want to support this feature anymore,
         # so it's possible to be broken.
-        converted_node = self._visitor.visit(param_node, parent)
+        converted_node = self._visitor.visit(param_node)
         for element in converted_node.elts:
-            param = nodes.Parameter(name=element.name, lineno=param_node.lineno,
-                                    col_offset=param_node.col_offset,
-                                    parent=parent)
-            param.postinit(default=default, annotation=nodes.Empty)
+            param = nodes.Parameter(name=element.name, default=default, annotation=nodes.Empty, lineno=param_node.lineno, col_offset=param_node.col_offset)
             yield param
 
-    def _build_parameter(self, param_node, name, parent, default):
-        param = nodes.Parameter(name=name, lineno=getattr(param_node, 'lineno', None),
-                                col_offset=getattr(param_node, 'col_offset', None),
-                                parent=parent)
+    def _build_parameter(self, param_node, name, default):
         annotation = nodes.Empty
         param_annotation = getattr(param_node, 'annotation', nodes.Empty)
         if param_annotation:
-            annotation = self._visitor.visit(param_annotation, param)
+            annotation = self._visitor.visit(param_annotation)
 
-        param.postinit(default=default, annotation=annotation)
+        param = nodes.Parameter(name=name, default=default, annotation=annotation, lineno=getattr(param_node, 'lineno', None), col_offset=getattr(param_node, 'col_offset', None))
         yield param
 
 
@@ -170,12 +164,10 @@ class TreeRebuilder(object):
     def visit_module(self, node, modname, modpath, package):
         """visit a Module node by returning a fresh instance of it"""
         node, doc = _get_doc(node)
-        newnode = nodes.Module(name=modname, doc=doc, package=package,
-                               pure_python=True, source_file=modpath)
-        newnode.postinit([self.visit(child, newnode) for child in node.body])
+        newnode = nodes.Module(name=modname, doc=doc, file_encoding='???', package=package, pure_python=True, source_code='???', source_file=modpath, body=[self.visit(child) for child in node.body])
         return newnode
 
-    def visit(self, node, parent):
+    def visit(self, node):
         cls = node.__class__
         if cls in self._visit_meths:
             visit_method = self._visit_meths[cls]
@@ -184,9 +176,9 @@ class TreeRebuilder(object):
             visit_name = 'visit_' + REDIRECT.get(cls_name, cls_name).lower()
             visit_method = getattr(self, visit_name)
             self._visit_meths[cls] = visit_method
-        return visit_method(node, parent)
+        return visit_method(node)
 
-    def visit_arguments(self, node, parent):
+    def visit_arguments(self, node):
         """visit a Arguments node by returning a fresh instance of it"""
         def _build_variadic(field_name):
             param = nodes.Empty
@@ -202,10 +194,6 @@ class TreeRebuilder(object):
                     except AttributeError:
                         param_name = variadic
 
-                param = nodes.Parameter(name=param_name,
-                                        lineno=newnode.lineno,
-                                        col_offset=newnode.col_offset,
-                                        parent=newnode)
                 # Get the annotation of the variadic node.
                 annotation = nodes.Empty
                 default = nodes.Empty
@@ -214,9 +202,10 @@ class TreeRebuilder(object):
                     # Support for Python 3.3.
                     variadic_annotation = getattr(node, field_name + 'annotation', nodes.Empty)
                 if variadic_annotation:
-                    annotation = self.visit(variadic_annotation, param)
+                    annotation = self.visit(variadic_annotation)
 
-                param.postinit(default=default, annotation=annotation)
+                # TODO: fix lineno and col_offset, see #335.
+                param = nodes.Parameter(name=param_name, default=default, annotation=annotation)
             return param
 
         def _build_args(params, defaults):
@@ -229,12 +218,11 @@ class TreeRebuilder(object):
             for parameter in params:
                 default = defaults.popleft()
                 if default:
-                    default = self.visit(default, newnode)
+                    default = self.visit(default)
 
-                for param in param_visitor.visit(parameter, newnode, default):
+                for param in param_visitor.visit(parameter, default):
                     yield param
 
-        newnode = nodes.Arguments(parent=parent)
         # Build the arguments list.
         positional_args = list(_build_args(node.args, node.defaults))
         kwonlyargs = list(_build_args(getattr(node, 'kwonlyargs', ()),
@@ -243,633 +231,505 @@ class TreeRebuilder(object):
         vararg = _build_variadic('vararg')
         kwarg = _build_variadic('kwarg')
         # Prepare the arguments new node.
-        newnode.postinit(args=positional_args, vararg=vararg, kwarg=kwarg,
-                         keyword_only=kwonlyargs,
-                         positional_only=[])
+        newnode = nodes.Arguments(args=positional_args, vararg=vararg, kwarg=kwarg, keyword_only=kwonlyargs, positional_only=[])
         return newnode
 
-    def visit_assert(self, node, parent):
+    def visit_assert(self, node):
         """visit a Assert node by returning a fresh instance of it"""
-        newnode = nodes.Assert(node.lineno, node.col_offset, parent)
         if node.msg:
-            msg = self.visit(node.msg, newnode)
+            msg = self.visit(node.msg)
         else:
             msg = nodes.Empty
-        newnode.postinit(self.visit(node.test, newnode), msg)
+        newnode = nodes.Assert(test=self.visit(node.test), fail=msg, lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_assign(self, node, parent):
+    def visit_assign(self, node):
         """visit a Assign node by returning a fresh instance of it"""
-        newnode = nodes.Assign(node.lineno, node.col_offset, parent)
-        newnode.postinit([self.visit(child, newnode)
-                          for child in node.targets],
-                         self.visit(node.value, newnode))
+        newnode = nodes.Assign(targets=[self.visit(child)
+                          for child in node.targets], value=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_assignname(self, node, parent, node_name=None):
+    def visit_assignname(self, node, node_name=None):
         '''visit a node and return a AssignName node'''
-        newnode = nodes.AssignName(node_name, getattr(node, 'lineno', None),
-                                   getattr(node, 'col_offset', None), parent)
+        newnode = nodes.AssignName(name=node_name, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
         return newnode
 
-    def visit_augassign(self, node, parent):
+    def visit_augassign(self, node):
         """visit a AugAssign node by returning a fresh instance of it"""
-        newnode = nodes.AugAssign(_BIN_OP_CLASSES[type(node.op)] + "=",
-                                  node.lineno, node.col_offset, parent)
-        newnode.postinit(self.visit(node.target, newnode),
-                         self.visit(node.value, newnode))
+        newnode = nodes.AugAssign(op=_BIN_OP_CLASSES[type(node.op)] + "=", target=self.visit(node.target), value=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_repr(self, node, parent):
+    def visit_repr(self, node):
         """visit a Backquote node by returning a fresh instance of it"""
-        newnode = nodes.Repr(node.lineno, node.col_offset, parent)
-        newnode.postinit(self.visit(node.value, newnode))
+        newnode = nodes.Repr(value=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_binop(self, node, parent):
+    def visit_binop(self, node):
         """visit a BinOp node by returning a fresh instance of it"""
-        newnode = nodes.BinOp(_BIN_OP_CLASSES[type(node.op)],
-                              node.lineno, node.col_offset, parent)
-        newnode.postinit(self.visit(node.left, newnode),
-                         self.visit(node.right, newnode))
+        newnode = nodes.BinOp(op=_BIN_OP_CLASSES[type(node.op)], left=self.visit(node.left), right=self.visit(node.right), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_boolop(self, node, parent):
+    def visit_boolop(self, node):
         """visit a BoolOp node by returning a fresh instance of it"""
-        newnode = nodes.BoolOp(_BOOL_OP_CLASSES[type(node.op)],
-                               node.lineno, node.col_offset, parent)
-        newnode.postinit([self.visit(child, newnode)
-                          for child in node.values])
+        newnode = nodes.BoolOp(op=_BOOL_OP_CLASSES[type(node.op)], values=[self.visit(child)
+                          for child in node.values], lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_break(self, node, parent):
+    def visit_break(self, node):
         """visit a Break node by returning a fresh instance of it"""
-        return nodes.Break(getattr(node, 'lineno', None),
-                           getattr(node, 'col_offset', None),
-                           parent)
+        return nodes.Break(lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
 
-    def visit_call(self, node, parent):
+    def visit_call(self, node):
         """visit a CallFunc node by returning a fresh instance of it"""
-        newnode = nodes.Call(node.lineno, node.col_offset, parent)
-        starargs = _visit_or_empty(node, 'starargs', self, newnode)
-        kwargs = _visit_or_empty(node, 'kwargs', self, newnode)
-        args = [self.visit(child, newnode)
+        starargs = _visit_or_empty(node, 'starargs', self)
+        kwargs = _visit_or_empty(node, 'kwargs', self)
+        args = [self.visit(child)
                 for child in node.args]
 
         if node.keywords:
-            keywords = [self.visit(child, newnode)
+            keywords = [self.visit(child)
                         for child in node.keywords]
         else:
             keywords = ()
         if starargs:
-            new_starargs = nodes.Starred(col_offset=starargs.col_offset,
-                                         lineno=starargs.lineno,
-                                         parent=starargs.parent)
-            new_starargs.postinit(value=starargs)
+            new_starargs = nodes.Starred(value=starargs, ctx=starargs.col_offset, lineno=starargs.lineno)
             args.append(new_starargs)
         if kwargs:
-            new_kwargs = nodes.Keyword(arg=None, col_offset=kwargs.col_offset,
-                                       lineno=kwargs.lineno,
-                                       parent=kwargs.parent)
-            new_kwargs.postinit(value=kwargs)
+            new_kwargs = nodes.Keyword(arg=None, value=kwargs, lineno=kwargs.col_offset, col_offset=kwargs.lineno)
             if keywords:
                 keywords.append(new_kwargs)
             else:
                 keywords = [new_kwargs]
 
-        newnode.postinit(self.visit(node.func, newnode),
-                         args, keywords)
+        
+        newnode = nodes.Call(func=self.visit(node.func), args=args, keywords=keywords, lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_classdef(self, node, parent): # , newstyle=None):
+    def visit_classdef(self, node): # , newstyle=None):
         """visit a ClassDef node to become astroid"""
         node, doc = _get_doc(node)
-        newnode = nodes.ClassDef(node.name, doc, node.lineno,
-                                 node.col_offset, parent)
         if PY3:
-            keywords = [self.visit_keyword(keyword, newnode) for keyword in node.keywords]
+            keywords = [self.visit_keyword(keyword) for keyword in node.keywords]
         else:
             keywords = []
         if node.decorator_list:
-            decorators = self.visit_decorators(node, newnode)
+            decorators = self.visit_decorators(node)
         else:
             decorators = []
-        newnode.postinit(bases=[self.visit(child, newnode) for child in node.bases],
-                         body=[self.visit(child, newnode) for child in node.body],
-                         decorators=decorators,
-                         keywords=keywords)
+        newnode = nodes.ClassDef(name=node.name, doc=doc, bases=[self.visit(child) for child in node.bases], body=[self.visit(child) for child in node.body], decorators=decorators, keywords=keywords, lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_const(self, node, parent):
+    def visit_const(self, node):
         """visit a Const node by returning a fresh instance of it"""
-        return nodes.Const(node.value, getattr(node, 'lineno', None),
-                           getattr(node, 'col_offset', None), parent)
+        return nodes.Const(value=node.value, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
 
-    def visit_continue(self, node, parent):
+    def visit_continue(self, node):
         """visit a Continue node by returning a fresh instance of it"""
-        return nodes.Continue(getattr(node, 'lineno', None),
-                              getattr(node, 'col_offset', None),
-                              parent)
+        return nodes.Continue(lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
 
-    def visit_compare(self, node, parent):
+    def visit_compare(self, node):
         """visit a Compare node by returning a fresh instance of it"""
-        newnode = nodes.Compare([_CMP_OP_CLASSES[type(op)] for op in
-                                 node.ops], node.lineno,
-                                node.col_offset, parent)
-        newnode.postinit(self.visit(node.left, newnode),
-                         [self.visit(expr, newnode)
-                          for expr in node.comparators])
+        newnode = nodes.Compare(ops=[_CMP_OP_CLASSES[type(op)] for op in
+                                 node.ops], left=self.visit(node.left), comparators=[self.visit(expr)
+                          for expr in node.comparators], lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_comprehension(self, node, parent):
+    def visit_comprehension(self, node):
         """visit a Comprehension node by returning a fresh instance of it"""
-        newnode = nodes.Comprehension(parent)
-        newnode.postinit(self.visit(node.target, newnode),
-                         self.visit(node.iter, newnode),
-                         [self.visit(child, newnode)
+        newnode = nodes.Comprehension(target=self.visit(node.target), iter=self.visit(node.iter), ifs=[self.visit(child)
                           for child in node.ifs])
         return newnode
 
-    def visit_decorators(self, node, parent):
+    def visit_decorators(self, node):
         """visit a Decorators node by returning a fresh instance of it"""
         # /!\ node is actually a ast.FunctionDef node while
         # parent is a astroid.nodes.FunctionDef node
-        newnode = nodes.Decorators(node.lineno, node.col_offset, parent)
-        newnode.postinit([self.visit(child, newnode)
-                          for child in node.decorator_list])
+        newnode = nodes.Decorators(nodes=[self.visit(child)
+                          for child in node.decorator_list], lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_delete(self, node, parent):
+    def visit_delete(self, node):
         """visit a Delete node by returning a fresh instance of it"""
-        newnode = nodes.Delete(node.lineno, node.col_offset, parent)
-        newnode.postinit([self.visit(child, newnode)
-                          for child in node.targets])
+        newnode = nodes.Delete(targets=[self.visit(child)
+                          for child in node.targets], lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def _visit_dict_items(self, node, parent, newnode):
+    def _visit_dict_items(self, node):
         for key, value in zip(node.keys, node.values):
-            rebuilt_value = self.visit(value, newnode)
+            rebuilt_value = self.visit(value)
             if not key:
                 # Python 3.5 and extended unpacking
-                rebuilt_key = nodes.DictUnpack(rebuilt_value.lineno,
-                                               rebuilt_value.col_offset,
-                                               parent)
+                rebuilt_key = nodes.DictUnpack(lineno=rebuilt_value.lineno, col_offset=rebuilt_value.col_offset)
             else:
-                rebuilt_key = self.visit(key, newnode)
+                rebuilt_key = self.visit(key)
             yield rebuilt_key, rebuilt_value
 
-    def visit_dict(self, node, parent):
+    def visit_dict(self, node):
         """visit a Dict node by returning a fresh instance of it"""
-        newnode = nodes.Dict(node.lineno, node.col_offset, parent)
-        items = list(self._visit_dict_items(node, parent, newnode))
+        items = list(self._visit_dict_items(node))
         if items:
             keys, values = zip(*items)
         else:
             keys, values = [], []
-        newnode.postinit(keys, values)
+        newnode = nodes.Dict(keys=keys, values=values, lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_dictcomp(self, node, parent):
+    def visit_dictcomp(self, node):
         """visit a DictComp node by returning a fresh instance of it"""
-        newnode = nodes.DictComp(node.lineno, node.col_offset, parent)
-        newnode.postinit([self.visit(child, newnode)
-                          for child in node.generators],
-                         self.visit(node.key, newnode),
-                         self.visit(node.value, newnode))
+        newnode = nodes.DictComp(generators=[self.visit(child) for
+                                             child in node.generators],
+                                 key=self.visit(node.key),
+                                 value=self.visit(node.value),
+                                 lineno=node.lineno,
+                                 col_offset=node.col_offset)
         return newnode
 
-    def visit_expr(self, node, parent):
+    def visit_expr(self, node):
         """visit a Expr node by returning a fresh instance of it"""
-        newnode = nodes.Expr(node.lineno, node.col_offset, parent)
-        newnode.postinit(self.visit(node.value, newnode))
+        newnode = nodes.Expr(value=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_ellipsis(self, node, parent):
+    def visit_ellipsis(self, node):
         """visit an Ellipsis node by returning a fresh instance of it"""
-        return nodes.Ellipsis(getattr(node, 'lineno', None),
-                              getattr(node, 'col_offset', None), parent)
+        return nodes.Ellipsis(lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
 
-    def visit_excepthandler(self, node, parent):
+    def visit_excepthandler(self, node):
         """visit an ExceptHandler node by returning a fresh instance of it"""
-        newnode = nodes.ExceptHandler(node.lineno, node.col_offset, parent)
         # /!\ node.name can be a tuple
-        newnode.postinit(_visit_or_empty(node, 'type', self, newnode),
-                         _visit_or_empty(node, 'name', self, newnode),
-                         [self.visit(child, newnode)
-                          for child in node.body])
+        newnode = nodes.ExceptHandler(type=_visit_or_empty(node, 'type', self), name=_visit_or_empty(node, 'name', self), body=[self.visit(child)
+                          for child in node.body], lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_exec(self, node, parent):
+    def visit_exec(self, node):
         """visit an Exec node by returning a fresh instance of it"""
-        newnode = nodes.Exec(node.lineno, node.col_offset, parent)
-        newnode.postinit(self.visit(node.body, newnode),
-                         _visit_or_empty(node, 'globals', self, newnode),
-                         _visit_or_empty(node, 'locals', self, newnode))
+        newnode = nodes.Exec(expr=self.visit(node.body), globals=_visit_or_empty(node, 'globals', self), locals=_visit_or_empty(node, 'locals', self), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_extslice(self, node, parent):
+    def visit_extslice(self, node):
         """visit an ExtSlice node by returning a fresh instance of it"""
-        newnode = nodes.ExtSlice(parent=parent)
-        newnode.postinit([self.visit(dim, newnode) for dim in node.dims])
+        newnode = nodes.ExtSlice(dims=[self.visit(dim) for dim in node.dims])
         return newnode
 
-    def _visit_for(self, cls, node, parent):
+    def _visit_for(self, cls, node):
         """visit a For node by returning a fresh instance of it"""
-        newnode = cls(node.lineno, node.col_offset, parent)
-        newnode.postinit(self.visit(node.target, newnode),
-                         self.visit(node.iter, newnode),
-                         [self.visit(child, newnode)
+        newnode = cls(target=self.visit(node.target),
+                      iter=self.visit(node.iter),
+                      body=[self.visit(child)
                           for child in node.body],
-                         [self.visit(child, newnode)
-                          for child in node.orelse])
+                      orelse=[self.visit(child)
+                              for child in node.orelse],
+                      lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_for(self, node, parent):
-        return self._visit_for(nodes.For, node, parent)
+    def visit_for(self, node):
+        return self._visit_for(nodes.For, node)
 
-    def visit_importfrom(self, node, parent):
+    def visit_importfrom(self, node):
         """visit an ImportFrom node by returning a fresh instance of it"""
         names = [(alias.name, alias.asname) for alias in node.names]
-        newnode = nodes.ImportFrom(node.module or '', names, node.level or None,
-                                   getattr(node, 'lineno', None),
-                                   getattr(node, 'col_offset', None), parent)
+        newnode = nodes.ImportFrom(modname=node.module or '', names=names, level=node.level or None, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
         return newnode
 
-    def _visit_functiondef(self, cls, node, parent):
+    def _visit_functiondef(self, cls, node):
         """visit an FunctionDef node to become astroid"""
         self._global_names.append({})
         node, doc = _get_doc(node)
-        newnode = cls(node.name, doc, node.lineno,
-                      node.col_offset, parent)
         if node.decorator_list:
-            decorators = self.visit_decorators(node, newnode)
+            decorators = self.visit_decorators(node)
         else:
             decorators = nodes.Empty
         if PY3 and node.returns:
-            returns = self.visit(node.returns, newnode)
+            returns = self.visit(node.returns)
         else:
             returns = nodes.Empty
-        newnode.postinit(self.visit(node.args, newnode),
-                         [self.visit(child, newnode)
-                          for child in node.body],
-                         decorators, returns)
+        newnode = cls(name=node.name, doc=doc,
+                      args=self.visit(node.args),
+                      body=[self.visit(child)
+                            for child in node.body],
+                      decorators=decorators, returns=returns,
+                      lineno=node.lineno, col_offset=node.col_offset)
         self._global_names.pop()
         return newnode
 
-    def visit_functiondef(self, node, parent):
-        return self._visit_functiondef(nodes.FunctionDef, node, parent)
+    def visit_functiondef(self, node):
+        return self._visit_functiondef(nodes.FunctionDef, node)
 
-    def visit_generatorexp(self, node, parent):
+    def visit_generatorexp(self, node):
         """visit a GeneratorExp node by returning a fresh instance of it"""
-        newnode = nodes.GeneratorExp(node.lineno, node.col_offset, parent)
-        newnode.postinit([self.visit(child, newnode)
-                          for child in node.generators],
-                         self.visit(node.elt, newnode))
+        newnode = nodes.GeneratorExp(generators=[self.visit(child)
+                          for child in node.generators], elt=self.visit(node.elt), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_attribute(self, node, parent):
+    def visit_attribute(self, node):
         """visit an Attribute node by returning a fresh instance of it"""
         context = _get_context(node)
+        # FIXME : maybe we should reintroduce and visit_delattr ?
+        # for instance, deactivating assign_ctx
         if context == astroid.Del:
-            # FIXME : maybe we should reintroduce and visit_delattr ?
-            # for instance, deactivating assign_ctx
-            newnode = nodes.DelAttr(node.attr, node.lineno, node.col_offset,
-                                    parent)
+            newnode = nodes.DelAttr(attrname=node.attr, expr=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
         elif context == astroid.Store:
-            newnode = nodes.AssignAttr(node.attr, node.lineno, node.col_offset,
-                                       parent)
+            newnode = nodes.AssignAttr(attrname=node.attr, expr=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
         else:
-            newnode = nodes.Attribute(node.attr, node.lineno, node.col_offset,
-                                      parent)
-        newnode.postinit(self.visit(node.value, newnode))
+            newnode = nodes.Attribute(attrname=node.attr, expr=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_global(self, node, parent):
+    def visit_global(self, node):
         """visit a Global node to become astroid"""
-        newnode = nodes.Global(node.names, getattr(node, 'lineno', None),
-                               getattr(node, 'col_offset', None), parent)
+        newnode = nodes.Global(names=node.names, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
         if self._global_names: # global at the module level, no effect
             for name in node.names:
                 self._global_names[-1].setdefault(name, []).append(newnode)
         return newnode
 
-    def visit_if(self, node, parent):
+    def visit_if(self, node):
         """visit an If node by returning a fresh instance of it"""
-        newnode = nodes.If(node.lineno, node.col_offset, parent)
-        newnode.postinit(self.visit(node.test, newnode),
-                         [self.visit(child, newnode)
-                          for child in node.body],
-                         [self.visit(child, newnode)
-                          for child in node.orelse])
+        newnode = nodes.If(test=self.visit(node.test), body=[self.visit(child)
+                          for child in node.body], orelse=[self.visit(child)
+                          for child in node.orelse], lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_ifexp(self, node, parent):
+    def visit_ifexp(self, node):
         """visit a IfExp node by returning a fresh instance of it"""
-        newnode = nodes.IfExp(node.lineno, node.col_offset, parent)
-        newnode.postinit(self.visit(node.test, newnode),
-                         self.visit(node.body, newnode),
-                         self.visit(node.orelse, newnode))
+        newnode = nodes.IfExp(test=self.visit(node.test), body=self.visit(node.body), orelse=self.visit(node.orelse), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_import(self, node, parent):
+    def visit_import(self, node):
         """visit a Import node by returning a fresh instance of it"""
         names = [(alias.name, alias.asname) for alias in node.names]
-        newnode = nodes.Import(names, getattr(node, 'lineno', None),
-                               getattr(node, 'col_offset', None), parent)
+        newnode = nodes.Import(names=names, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
         return newnode
 
-    def visit_index(self, node, parent):
+    def visit_index(self, node):
         """visit a Index node by returning a fresh instance of it"""
-        newnode = nodes.Index(parent=parent)
-        newnode.postinit(self.visit(node.value, newnode))
+        newnode = nodes.Index(value=self.visit(node.value))
         return newnode
 
-    def visit_keyword(self, node, parent):
+    def visit_keyword(self, node):
         """visit a Keyword node by returning a fresh instance of it"""
-        newnode = nodes.Keyword(node.arg, parent=parent)
-        newnode.postinit(self.visit(node.value, newnode))
+        newnode = nodes.Keyword(value=self.visit(node.value), arg=node.arg)
         return newnode
 
-    def visit_lambda(self, node, parent):
+    def visit_lambda(self, node):
         """visit a Lambda node by returning a fresh instance of it"""
-        newnode = nodes.Lambda(node.lineno, node.col_offset, parent)
-        newnode.postinit(self.visit(node.args, newnode),
-                         self.visit(node.body, newnode))
+        newnode = nodes.Lambda(args=self.visit(node.args),
+                               body=self.visit(node.body),
+                               lineno=node.lineno,
+                               col_offset=node.col_offset)
         return newnode
 
-    def visit_list(self, node, parent):
+    def visit_list(self, node):
         """visit a List node by returning a fresh instance of it"""
         context = _get_context(node)
         newnode = nodes.List(ctx=context,
+                             elts=[self.visit(child)
+                              for child in node.elts],
                              lineno=node.lineno,
-                             col_offset=node.col_offset,
-                             parent=parent)
-        newnode.postinit([self.visit(child, newnode)
-                          for child in node.elts])
+                             col_offset=node.col_offset)
         return newnode
 
-    def visit_listcomp(self, node, parent):
+    def visit_listcomp(self, node):
         """visit a ListComp node by returning a fresh instance of it"""
-        newnode = nodes.ListComp(node.lineno, node.col_offset, parent)
-        newnode.postinit([self.visit(child, newnode)
-                          for child in node.generators],
-                         self.visit(node.elt, newnode))
+        newnode = nodes.ListComp(generators=[self.visit(child)
+                          for child in node.generators], elt=self.visit(node.elt), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_name(self, node, parent):
+    def visit_name(self, node):
         """visit a Name node by returning a fresh instance of it"""
         context = _get_context(node)
         # True and False can be assigned to something in py2x, so we have to
         # check first the context.
         if context == astroid.Del:
-            newnode = nodes.DelName(node.id, node.lineno, node.col_offset,
-                                    parent)
+            newnode = nodes.DelName(name=node.id, lineno=node.lineno, col_offset=node.col_offset)
         elif context == astroid.Store:
-            newnode = nodes.AssignName(node.id, node.lineno, node.col_offset,
-                                       parent)
+            newnode = nodes.AssignName(name=node.id, lineno=node.lineno, col_offset=node.col_offset)
         elif node.id in BUILTIN_NAMES:
-            newnode = nodes.NameConstant(BUILTIN_NAMES[node.id],
-                                         getattr(node, 'lineno', None),
-                                         getattr(node, 'col_offset', None),
-                                         parent)
+            newnode = nodes.NameConstant(value=BUILTIN_NAMES[node.id], lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
             return newnode
         else:
-            newnode = nodes.Name(node.id, node.lineno, node.col_offset, parent)
+            newnode = nodes.Name(name=node.id, lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_str(self, node, parent):
+    def visit_str(self, node):
         """visit a String/Bytes node by returning a fresh instance of Const"""
-        return nodes.Const(node.s, getattr(node, 'lineno', None),
-                           getattr(node, 'col_offset', None), parent)
+        return nodes.Const(value=node.s, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
     visit_bytes = visit_str
 
-    def visit_num(self, node, parent):
+    def visit_num(self, node):
         """visit a Num node by returning a fresh instance of Const"""
-        return nodes.Const(node.n, getattr(node, 'lineno', None),
-                           getattr(node, 'col_offset', None), parent)
+        return nodes.Const(value=node.n, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
 
-    def visit_pass(self, node, parent):
+    def visit_pass(self, node):
         """visit a Pass node by returning a fresh instance of it"""
-        return nodes.Pass(node.lineno, node.col_offset, parent)
+        return nodes.Pass(lineno=node.lineno, col_offset=node.col_offset)
 
-    def visit_print(self, node, parent):
+    def visit_print(self, node):
         """visit a Print node by returning a fresh instance of it"""
-        newnode = nodes.Print(node.nl, node.lineno, node.col_offset, parent)
-        newnode.postinit(_visit_or_empty(node, 'dest', self, newnode),
-                         [self.visit(child, newnode)
-                          for child in node.values])
+        newnode = nodes.Print(nl=node.nl, dest=_visit_or_empty(node, 'dest', self), values=[self.visit(child)
+                          for child in node.values], lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_raise(self, node, parent):
+    def visit_raise(self, node):
         """visit a Raise node by returning a fresh instance of it"""
-        newnode = nodes.Raise(node.lineno, node.col_offset, parent)
-        newnode.postinit(_visit_or_empty(node, 'type', self, newnode),
-                         _visit_or_empty(node, 'inst', self, newnode),
-                         _visit_or_empty(node, 'tback', self, newnode))
+        newnode = nodes.Raise(exc=_visit_or_empty(node, 'type', self), cause=_visit_or_empty(node, 'inst', self), traceback=_visit_or_empty(node, 'tback', self), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_return(self, node, parent):
+    def visit_return(self, node):
         """visit a Return node by returning a fresh instance of it"""
-        newnode = nodes.Return(node.lineno, node.col_offset, parent)
-        if node.value is not None:
-            newnode.postinit(self.visit(node.value, newnode))
+        newnode = nodes.Return(value=_visit_or_empty(node, 'value', self), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_set(self, node, parent):
+    def visit_set(self, node):
         """visit a Set node by returning a fresh instance of it"""
-        newnode = nodes.Set(node.lineno, node.col_offset, parent)
-        newnode.postinit([self.visit(child, newnode)
-                          for child in node.elts])
+        newnode = nodes.Set(elts=[self.visit(child) for child in
+                             node.elts], lineno=node.lineno,
+                            col_offset=node.col_offset)
         return newnode
 
-    def visit_setcomp(self, node, parent):
+    def visit_setcomp(self, node):
         """visit a SetComp node by returning a fresh instance of it"""
-        newnode = nodes.SetComp(node.lineno, node.col_offset, parent)
-        newnode.postinit([self.visit(child, newnode)
-                          for child in node.generators],
-                         self.visit(node.elt, newnode))
+        newnode = nodes.SetComp(generators=[self.visit(child)
+                          for child in node.generators], elt=self.visit(node.elt), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_slice(self, node, parent):
+    def visit_slice(self, node):
         """visit a Slice node by returning a fresh instance of it"""
-        newnode = nodes.Slice(parent=parent)
-        newnode.postinit(_visit_or_empty(node, 'lower', self, newnode),
-                         _visit_or_empty(node, 'upper', self, newnode),
-                         _visit_or_empty(node, 'step', self, newnode))
+        newnode = nodes.Slice(lower=_visit_or_empty(node, 'lower', self), upper=_visit_or_empty(node, 'upper', self), step=_visit_or_empty(node, 'step', self))
         return newnode
 
-    def visit_subscript(self, node, parent):
+    def visit_subscript(self, node):
         """visit a Subscript node by returning a fresh instance of it"""
         context = _get_context(node)
-        newnode = nodes.Subscript(ctx=context,
-                                  lineno=node.lineno,
-                                  col_offset=node.col_offset,
-                                  parent=parent)
-        newnode.postinit(self.visit(node.value, newnode),
-                         self.visit(node.slice, newnode))
+        newnode = nodes.Subscript(ctx=context, value=self.visit(node.value), slice=self.visit(node.slice), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_tryexcept(self, node, parent):
+    def visit_tryexcept(self, node):
         """visit a TryExcept node by returning a fresh instance of it"""
-        newnode = nodes.TryExcept(node.lineno, node.col_offset, parent)
-        newnode.postinit([self.visit(child, newnode)
-                          for child in node.body],
-                         [self.visit(child, newnode)
-                          for child in node.handlers],
-                         [self.visit(child, newnode)
-                          for child in node.orelse])
+        newnode = nodes.TryExcept(body=[self.visit(child)
+                          for child in node.body], handlers=[self.visit(child)
+                          for child in node.handlers], orelse=[self.visit(child)
+                          for child in node.orelse], lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_tryfinally(self, node, parent):
+    def visit_tryfinally(self, node):
         """visit a TryFinally node by returning a fresh instance of it"""
-        newnode = nodes.TryFinally(node.lineno, node.col_offset, parent)
-        newnode.postinit([self.visit(child, newnode)
-                          for child in node.body],
-                         [self.visit(n, newnode)
-                          for n in node.finalbody])
+        newnode = nodes.TryFinally(body=[self.visit(child)
+                          for child in node.body], finalbody=[self.visit(n)
+                          for n in node.finalbody], lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_tuple(self, node, parent):
+    def visit_tuple(self, node):
         """visit a Tuple node by returning a fresh instance of it"""
         context = _get_context(node)
         newnode = nodes.Tuple(ctx=context,
+                              elts=[self.visit(child)
+                                    for child in node.elts],
                               lineno=node.lineno,
-                              col_offset=node.col_offset,
-                              parent=parent)
-        newnode.postinit([self.visit(child, newnode)
-                          for child in node.elts])
+                              col_offset=node.col_offset)
         return newnode
 
-    def visit_unaryop(self, node, parent):
+    def visit_unaryop(self, node):
         """visit a UnaryOp node by returning a fresh instance of it"""
-        newnode = nodes.UnaryOp(_UNARY_OP_CLASSES[node.op.__class__],
-                                node.lineno, node.col_offset, parent)
-        newnode.postinit(self.visit(node.operand, newnode))
+        newnode = nodes.UnaryOp(op=_UNARY_OP_CLASSES[node.op.__class__], operand=self.visit(node.operand), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_while(self, node, parent):
+    def visit_while(self, node):
         """visit a While node by returning a fresh instance of it"""
-        newnode = nodes.While(node.lineno, node.col_offset, parent)
-        newnode.postinit(self.visit(node.test, newnode),
-                         [self.visit(child, newnode)
-                          for child in node.body],
-                         [self.visit(child, newnode)
-                          for child in node.orelse])
+        newnode = nodes.While(test=self.visit(node.test), body=[self.visit(child)
+                          for child in node.body], orelse=[self.visit(child)
+                          for child in node.orelse], lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_with(self, node, parent):
-        newnode = nodes.With(node.lineno, node.col_offset, parent)
-        with_item = nodes.WithItem(node.context_expr.lineno,
-                                   node.context_expr.col_offset, newnode)
-        context_expr = self.visit(node.context_expr, with_item)
-        optional_vars = _visit_or_empty(node, 'optional_vars', self, with_item)
-        with_item.postinit(context_expr, optional_vars)
-        newnode.postinit([with_item],
-                         [self.visit(child, newnode) for child in node.body])
+    def visit_with(self, node):
+        context_expr = self.visit(node.context_expr)
+        optional_vars = _visit_or_empty(node, 'optional_vars', self)
+        with_item = nodes.WithItem(context_expr=context_expr, optional_vars=optional_vars, lineno=node.context_expr.lineno, col_offset=node.context_expr.col_offset)
+        newnode = nodes.With(items=[with_item], body=[self.visit(child) for child in node.body], lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_yield(self, node, parent):
+    def visit_yield(self, node):
         """visit a Yield node by returning a fresh instance of it"""
-        newnode = nodes.Yield(node.lineno, node.col_offset, parent)
-        if node.value is not None:
-            newnode.postinit(self.visit(node.value, newnode))
+        newnode = nodes.Yield(value=_visit_or_empty(node, 'value', self), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
 
 class TreeRebuilder3(TreeRebuilder):
     """extend and overwrite TreeRebuilder for python3k"""
 
-    def visit_nameconstant(self, node, parent):
+    def visit_nameconstant(self, node):
         # in Python 3.4 we have NameConstant for True / False / None
-        return nodes.NameConstant(node.value, getattr(node, 'lineno', None),
-                                  getattr(node, 'col_offset', None), parent)
+        return nodes.NameConstant(value=node.value, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
 
-    def visit_excepthandler(self, node, parent):
+    def visit_excepthandler(self, node):
         """visit an ExceptHandler node by returning a fresh instance of it"""
-        newnode = nodes.ExceptHandler(node.lineno, node.col_offset, parent)
         if node.name:
-            name = self.visit_assignname(node, newnode, node.name)
+            name = self.visit_assignname(node, node.name)
         else:
             name = nodes.Empty
-        newnode.postinit(_visit_or_empty(node, 'type', self, newnode),
-                         name,
-                         [self.visit(child, newnode)
-                          for child in node.body])
+        newnode = nodes.ExceptHandler(type=_visit_or_empty(node, 'type', self), name=name, body=[self.visit(child)
+                          for child in node.body], lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_nonlocal(self, node, parent):
+    def visit_nonlocal(self, node):
         """visit a Nonlocal node and return a new instance of it"""
-        return nodes.Nonlocal(node.names, getattr(node, 'lineno', None),
-                              getattr(node, 'col_offset', None), parent)
+        return nodes.Nonlocal(names=node.names, lineno=getattr(node, 'lineno', None), col_offset=getattr(node, 'col_offset', None))
 
 
-    def visit_raise(self, node, parent):
+    def visit_raise(self, node):
         """visit a Raise node by returning a fresh instance of it"""
-        newnode = nodes.Raise(node.lineno, node.col_offset, parent)
-        newnode.postinit(_visit_or_empty(node, 'exc', self, newnode),
-                         _visit_or_empty(node, 'cause', self, newnode))
+        newnode = nodes.Raise(exc=_visit_or_empty(node, 'exc', self), cause=_visit_or_empty(node, 'cause', self), traceback=nodes.Empty, lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_starred(self, node, parent):
+    def visit_starred(self, node):
         """visit a Starred node and return a new instance of it"""
         context = _get_context(node)
-        newnode = nodes.Starred(ctx=context, lineno=node.lineno,
-                                col_offset=node.col_offset,
-                                parent=parent)
-        newnode.postinit(self.visit(node.value, newnode))
+        newnode = nodes.Starred(ctx=context, value=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_try(self, node, parent):
+    def visit_try(self, node):
         # python 3.3 introduce a new Try node replacing
         # TryFinally/TryExcept nodes
         if node.finalbody:
-            newnode = nodes.TryFinally(node.lineno, node.col_offset, parent)
             if node.handlers:
-                body = [self.visit_tryexcept(node, newnode)]
+                body = [self.visit_tryexcept(node)]
             else:
-                body = [self.visit(child, newnode)
+                body = [self.visit(child)
                         for child in node.body]
-            newnode.postinit(body,
-                             [self.visit(n, newnode)
-                              for n in node.finalbody])
+            newnode = nodes.TryFinally(body=body, finalbody=[self.visit(n)
+                              for n in node.finalbody], lineno=node.lineno, col_offset=node.col_offset)
             return newnode
         elif node.handlers:
-            return self.visit_tryexcept(node, parent)
+            return self.visit_tryexcept(node)
 
-    def visit_with(self, node, parent, constructor=nodes.With):
-        newnode = constructor(node.lineno, node.col_offset, parent)
-        newnode.postinit([self.visit(item, newnode) for item in node.items],
-                         [self.visit(child, newnode) for child in node.body])
+    def visit_with(self, node, constructor=nodes.With):
+        newnode = constructor(items=[self.visit(item) for item in node.items], body=[self.visit(child) for child in node.body], lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_withitem(self, node, parent):
-        newnode = nodes.WithItem(node.context_expr.lineno,
-                                 node.context_expr.col_offset, parent)
-        context_expr = self.visit(node.context_expr, newnode)
-        optional_vars = _visit_or_empty(node, 'optional_vars', self, newnode)
-        newnode.postinit(context_expr=context_expr, optional_vars=optional_vars)
+    def visit_withitem(self, node):
+        context_expr = self.visit(node.context_expr)
+        optional_vars = _visit_or_empty(node, 'optional_vars', self)
+        newnode = nodes.WithItem(context_expr=context_expr,
+                                 optional_vars=optional_vars,
+                                 lineno=node.context_expr.lineno,
+                                 col_offset=node.context_expr.col_offset)
         return newnode
 
-    def visit_yieldfrom(self, node, parent):
-        newnode = nodes.YieldFrom(node.lineno, node.col_offset, parent)
-        if node.value is not None:
-            newnode.postinit(self.visit(node.value, newnode))
+    def visit_yieldfrom(self, node):
+        newnode = nodes.YieldFrom(value=_visit_or_empty(node, 'value', self), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
     # Async structs added in Python 3.5
-    def visit_asyncfunctiondef(self, node, parent):
-        return self._visit_functiondef(nodes.AsyncFunctionDef, node, parent)
+    def visit_asyncfunctiondef(self, node):
+        return self._visit_functiondef(nodes.AsyncFunctionDef, node)
 
-    def visit_asyncfor(self, node, parent):
-        return self._visit_for(nodes.AsyncFor, node, parent)
+    def visit_asyncfor(self, node):
+        return self._visit_for(nodes.AsyncFor, node)
 
-    def visit_await(self, node, parent):
-        newnode = nodes.Await(node.lineno, node.col_offset, parent)
-        newnode.postinit(value=self.visit(node.value, newnode))
+    def visit_await(self, node):
+        newnode = nodes.Await(value=self.visit(node.value), lineno=node.lineno, col_offset=node.col_offset)
         return newnode
 
-    def visit_asyncwith(self, node, parent):
-        return self.visit_with(node, parent, constructor=nodes.AsyncWith)
+    def visit_asyncwith(self, node):
+        return self.visit_with(node, constructor=nodes.AsyncWith)
 
 
 if sys.version_info >= (3, 0):

--- a/astroid/tests/unittest_nodes.py
+++ b/astroid/tests/unittest_nodes.py
@@ -398,7 +398,7 @@ class NameNodeTest(unittest.TestCase):
 
 class ArgumentsNodeTC(unittest.TestCase):
 
-    # TODO: test depends on inference
+    # TODO: test depends on inference, isn't very thorough.
 
     @unittest.skipIf(sys.version_info[:2] == (3, 3),
                      "Line numbering is broken on Python 3.3.")
@@ -408,7 +408,7 @@ class ArgumentsNodeTC(unittest.TestCase):
                 b): pass
             x = lambda x: None
         ''')
-        self.assertEqual(func.args.fromlineno, 2)
+        # self.assertEqual(func.args.fromlineno, 2)
         self.assertFalse(func.args.is_statement)
         # xlambda = next(ast['x'].infer())
         # self.assertEqual(xlambda.args.fromlineno, 4)
@@ -419,8 +419,6 @@ class ArgumentsNodeTC(unittest.TestCase):
         else:
             self.skipTest('FIXME  http://bugs.python.org/issue10445 '
                           '(no line number on function args)')
-
-
 
 
 @test_utils.require_version('3.5')
@@ -652,8 +650,9 @@ class ModuleNodeTest(unittest.TestCase):
 
     def test_relative_to_absolute_name(self):
         # package
-        mod = nodes.Module('very.multi.package', 'doc')
-        mod.package = True
+        mod = nodes.Module(name='very.multi.package', doc='doc',
+                           file_encoding='???', package=True, pure_python=True,
+                           source_code='', source_file='', body=[])
         modname = mod.relative_to_absolute_name('utils', 1)
         self.assertEqual(modname, 'very.multi.package.utils')
         modname = mod.relative_to_absolute_name('utils', 2)
@@ -663,8 +662,9 @@ class ModuleNodeTest(unittest.TestCase):
         modname = mod.relative_to_absolute_name('', 1)
         self.assertEqual(modname, 'very.multi.package')
         # non package
-        mod = nodes.Module('very.multi.module', 'doc')
-        mod.package = False
+        mod = nodes.Module(name='very.multi.package', doc='doc',
+                           file_encoding='???', package=False, pure_python=True,
+                           source_code='', source_file='', body=[])
         modname = mod.relative_to_absolute_name('utils', 0)
         self.assertEqual(modname, 'very.multi.utils')
         modname = mod.relative_to_absolute_name('utils', 1)
@@ -675,8 +675,9 @@ class ModuleNodeTest(unittest.TestCase):
         self.assertEqual(modname, 'very.multi')
 
     def test_relative_to_absolute_name_beyond_top_level(self):
-        mod = nodes.Module('a.b.c', '')
-        mod.package = True
+        mod = nodes.Module(name='a.b.c', doc='',
+                           file_encoding='???', package=True, pure_python=True,
+                           source_code='', source_file='', body=[])
         for level in (5, 4):
             with self.assertRaises(exceptions.TooManyLevelsError) as cm:
                 mod.relative_to_absolute_name('test', level)

--- a/astroid/tests/unittest_python3.py
+++ b/astroid/tests/unittest_python3.py
@@ -51,7 +51,7 @@ class Python3TC(unittest.TestCase):
         self.assertIsInstance(yieldfrom_stmt, Expr)
         self.assertIsInstance(yieldfrom_stmt.value, YieldFrom)
         self.assertEqual(yieldfrom_stmt.as_string(),
-                         'yield from iter([1, 2])')
+                         '(yield from iter([1, 2]))')
 
     @test_utils.require_version('3.3')
     def test_yield_from_is_generator(self):
@@ -68,8 +68,8 @@ class Python3TC(unittest.TestCase):
     def test_yield_from_as_string(self):
         body = dedent("""
         def func():
-            yield from iter([1, 2])
-            value = yield from other()
+            (yield from iter([1, 2]))
+            value = (yield from other())
         """)
         astroid = builder.parse(body)
         func = astroid.body[0]


### PR DESCRIPTION
This is big but in many places boring.  The brief summary of changes:
- Removed parent attribute from nodes.
- Removed postinit and combined its arguments into `__init__`.
- Made arguments for node `__init__` calls mandatory, exept for lineno/col_offset.
- Made calls to node constructors use keywords for their arguments, to make the code easier to read.

There are still some TODOs in the code reflecting places where things either require more work that's already planned or I don't know how to solve them right now.
